### PR TITLE
Feature/live display 17

### DIFF
--- a/server/api/resultados_jug.php
+++ b/server/api/resultados_jug.php
@@ -4,6 +4,11 @@
  * GET /api/resultados_jug.php?catid=XXX&torneoid=XXX&gross=0|1
  * Returns tournament results for a category
  * Supports: Stroke Play (Neto/Gross), Stableford (Neto/Gross)
+ *
+ * IMPORTANT: Totals only include CLOSED scorecards (statlsc = 1)
+ * to avoid counting partial live scoring data.
+ * Per-day functions (f_score_dia_sax/sox) already use v_resultar
+ * which filters by statlsc = 1.
  */
 require_once 'config.php';
 
@@ -56,21 +61,33 @@ $sql = "SELECT b.campoid, b.salidaid, rating, slope, tee, parcampo
         LIMIT 1";
 $courseInfo = query_one($conn, $sql);
 
+// ============= Inline subquery helpers for closed-card totals =============
+// These replace the DB functions (f_torneosa, f_torneoso, etc.) which do NOT
+// filter by statlsc, causing partial live scoring data to inflate totals.
+
+/** Sum SA (neto/stableford points) from CLOSED cards only */
+$closedSA  = "(SELECT IFNULL(SUM(t.SA), 0) FROM tarjetas t WHERE t.jugadorid = j.id AND t.torneoid = j.torneoid AND t.statlsc = 1)";
+
+/** Sum SO (gross strokes) from CLOSED cards only */
+$closedSO  = "(SELECT IFNULL(SUM(t.SO), 0) FROM tarjetas t WHERE t.jugadorid = j.id AND t.torneoid = j.torneoid AND t.statlsc = 1)";
+
+/** Sum totstbgross (stableford gross points) from CLOSED cards only */
+$closedSTBGross = "(SELECT IFNULL(SUM(t.totstbgross), 0) FROM tarjetas t WHERE t.jugadorid = j.id AND t.torneoid = j.torneoid AND t.statlsc = 1)";
+
 // ============= Build main results query =============
 $players = [];
 
 if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
 
     if ($gross == '1') {
-        // GROSS results — query directly from jugadores table
-        // GROSS results — select muerte subita for priority tiebreaker
+        // GROSS results — only closed scorecards in totals
         $sql = "SELECT j.id AS jugadorid, j.numjugador,
                        CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
-                       f_torneosox(j.id, j.torneoid) as so,
-                       f_torneosax(j.id, j.torneoid) as sa,
+                       $closedSO as so,
+                       $closedSA as sa,
                        IFNULL(j.muertesubita, 0) as muertesubita";
 
-        // Add per-day scores (gross uses sox)
+        // Per-day scores (already filtered via v_resultar → statlsc = 1)
         foreach ($dias as $i => $fecha) {
             $sql .= ", f_score_dia_sox(j.id, '$fecha') as d{$i}";
         }
@@ -83,7 +100,7 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
                    AND j.torneoid = $tid
                    AND f_torneoso(j.id, j.torneoid) > 0
                    AND j.estatus = 'NORMAL'
-                 ORDER BY f_torneosox(j.id, j.torneoid) ASC";
+                 ORDER BY $closedSO ASC";
 
         // Priority tiebreaker: muerte subita (highest wins, 0/NULL = no value)
         $sql .= ", IFNULL(j.muertesubita, 0) DESC";
@@ -96,14 +113,14 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
         $sql .= ", u.c1 ASC, u.c2 ASC, u.c3 ASC";
 
     } else {
-        // NETO results — select muerte subita for priority tiebreaker
+        // NETO results — only closed scorecards in totals
         $sql = "SELECT j.id AS jugadorid, j.numjugador,
                        CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
-                       f_torneosax(j.id, j.torneoid) as sa,
-                       f_torneosox(j.id, j.torneoid) as so,
+                       $closedSA as sa,
+                       $closedSO as so,
                        IFNULL(j.muertesubita, 0) as muertesubita";
 
-        // Add per-day scores (neto uses sax)
+        // Per-day scores (already filtered via v_resultar → statlsc = 1)
         foreach ($dias as $i => $fecha) {
             $sql .= ", f_score_dia_sax(j.id, '$fecha') as d{$i}";
         }
@@ -117,7 +134,7 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
                    AND f_torneoso(j.id, j.torneoid) > 0
                    AND j.estatus = 'NORMAL'
                    AND j.campgross = 0
-                 ORDER BY f_torneosax(j.id, j.torneoid) ASC";
+                 ORDER BY $closedSA ASC";
 
         // Priority tiebreaker: muerte subita (highest wins, 0/NULL = no value)
         $sql .= ", IFNULL(j.muertesubita, 0) DESC";
@@ -133,14 +150,14 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
 } elseif ($sistema === 'STABLEFORD') {
 
     if ($gross == '1') {
-        // Stableford GROSS — select muerte subita for priority tiebreaker
+        // Stableford GROSS — only closed scorecards in totals
         $sql = "SELECT j.id AS jugadorid, j.numjugador,
                        CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
-                       f_stl_gross(j.id, j.torneoid) as sa,
-                       f_torneosox(j.id, j.torneoid) as so,
+                       $closedSTBGross as sa,
+                       $closedSO as so,
                        IFNULL(j.muertesubita, 0) as muertesubita";
 
-        // Add per-day scores (gross uses sox)
+        // Per-day scores (already filtered via v_resultar → statlsc = 1)
         foreach ($dias as $i => $fecha) {
             $sql .= ", f_score_dia_sox(j.id, '$fecha') as d{$i}";
         }
@@ -153,7 +170,7 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
                    AND j.torneoid = $tid
                    AND f_torneoso(j.id, j.torneoid) > 0
                    AND j.estatus = 'NORMAL'
-                 ORDER BY f_stl_gross(j.id, j.torneoid) DESC";
+                 ORDER BY $closedSTBGross DESC";
 
         // Priority tiebreaker: muerte subita (highest wins, 0/NULL = no value)
         $sql .= ", IFNULL(j.muertesubita, 0) DESC";
@@ -165,14 +182,14 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
         // Secondary tiebreakers
         $sql .= ", u.c1 DESC, u.c2 DESC, u.c3 DESC";
     } else {
-        // Stableford NETO — select muerte subita for priority tiebreaker
+        // Stableford NETO — only closed scorecards in totals
         $sql = "SELECT j.id AS jugadorid, j.numjugador,
                        CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
-                       f_torneosa(j.id, j.torneoid) as sa,
-                       f_torneosox(j.id, j.torneoid) as so,
+                       $closedSA as sa,
+                       $closedSO as so,
                        IFNULL(j.muertesubita, 0) as muertesubita";
 
-        // Add per-day scores (neto uses sax)
+        // Per-day scores (already filtered via v_resultar → statlsc = 1)
         foreach ($dias as $i => $fecha) {
             $sql .= ", f_score_dia_sax(j.id, '$fecha') as d{$i}";
         }
@@ -186,7 +203,7 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
                    AND f_torneoso(j.id, j.torneoid) > 0
                    AND j.estatus = 'NORMAL'
                    AND j.campgross = 0
-                 ORDER BY f_torneosa(j.id, j.torneoid) DESC";
+                 ORDER BY $closedSA DESC";
 
         // Priority tiebreaker: muerte subita (highest wins, 0/NULL = no value)
         $sql .= ", IFNULL(j.muertesubita, 0) DESC";

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -154,6 +154,20 @@ export const getResultadosTarjetaUrl = (
   })}`;
 
 /**
+ * Live Tarjeta (real-time scorecard) for a player
+ * @param jugadorId - Player ID
+ * @param tipo - Scoring type: stroke | stableford | goro_neto | goro_gross
+ */
+export const getLiveTarjetaUrl = (
+  jugadorId: string,
+  tipo: string = 'stroke'
+): string =>
+  `${API_BASE_URL}/live_tarjeta.php${buildQuery({
+    jugadorid: jugadorId,
+    tipo,
+  })}`;
+
+/**
  * Get full logo URL from logo filename
  * @param logoFilename - Logo filename from API response
  */

--- a/src/hooks/useResultadosData.ts
+++ b/src/hooks/useResultadosData.ts
@@ -6,7 +6,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/apiClient';
-import { getResultadosUrl, getResultadosCategoryUrl, getResultadosTarjetaUrl, POLL_ACTIVE } from '@/config/api';
+import { getResultadosUrl, getResultadosCategoryUrl, getResultadosTarjetaUrl, getLiveTarjetaUrl, POLL_ACTIVE } from '@/config/api';
 import type { ResultCategory, RoundScorecard, HoleScore, ScorecardType } from '@/data/resultadosData';
 
 // ============= All Results =============

--- a/src/hooks/useResultadosData.ts
+++ b/src/hooks/useResultadosData.ts
@@ -246,3 +246,76 @@ export const fetchPlayerScorecardFromApi = async (
     in: raw.totals?.inSO ?? back9.reduce((s, h) => s + h.golpes, 0),
   };
 };
+
+// ============= Live Scorecard =============
+
+/**
+ * Fetch a player's live (real-time) scorecard from live_tarjeta.php
+ * Maps the flat response into the same RoundScorecard structure used by Resultados
+ * @param playerId - Player ID
+ * @param tipo - Scoring type: stroke | stableford
+ * @param scoringType - NETO or GROSS (for display purposes)
+ */
+export const fetchLiveScorecardFromApi = async (
+  playerId: string,
+  tipo: string,
+  scoringType: string = 'NETO'
+): Promise<RoundScorecard> => {
+  const scType = tipo === 'stableford' ? 'stableford' : (scoringType === 'GROSS' ? 'scratch' : 'hcp');
+
+  const url = getLiveTarjetaUrl(playerId, tipo);
+  const raw = await apiFetch<any>(url);
+
+  // Parse par and ventajas arrays from the response
+  const parArr: number[] = raw.par || [];
+  const ventajasArr: number[] = raw.ventajas || [];
+  const holesSOArr: (number | null)[] = raw.holes || [];
+  const holesSAArr: (number | null)[] = raw.holesSA || [];
+
+  const isStableford = scType === 'stableford';
+
+  // Map into HoleScore[]
+  const holes: HoleScore[] = [];
+  for (let i = 0; i < 18; i++) {
+    const par = parArr[i] ?? 0;
+    const golpes = holesSOArr[i] ?? 0;
+    const hcpStrokes = ventajasArr[i] ?? 0;
+    const scoreSA = holesSAArr[i] ?? 0;
+    const diff = golpes - par;
+
+    const neto = isStableford ? (golpes - hcpStrokes) : scoreSA;
+    const puntos = isStableford ? scoreSA : undefined;
+
+    holes.push({
+      hoyo: i + 1,
+      par,
+      hcp: 0, // live_tarjeta doesn't return ventaja ranking per hole
+      golpes,
+      neto,
+      hcpStrokes,
+      puntos,
+      resultado: diff === 0 ? 'E' : diff > 0 ? `+${diff}` : `${diff}`,
+    });
+  }
+
+  const front9 = holes.slice(0, 9);
+  const back9 = holes.slice(9, 18);
+
+  const totalNeto = isStableford
+    ? holes.reduce((s, h) => s + h.neto, 0)
+    : (raw.totals?.SA ?? holes.reduce((s, h) => s + h.neto, 0));
+  const totalPuntos = isStableford
+    ? (raw.totals?.SA ?? holes.reduce((s, h) => s + (h.puntos || 0), 0))
+    : undefined;
+
+  return {
+    round: 0, // live — no specific round number
+    scorecardType: scType,
+    holes,
+    totalGolpes: raw.totals?.SO ?? holes.reduce((s, h) => s + h.golpes, 0),
+    totalNeto,
+    totalPuntos,
+    out: raw.totals?.outSO ?? front9.reduce((s, h) => s + h.golpes, 0),
+    in: raw.totals?.inSO ?? back9.reduce((s, h) => s + h.golpes, 0),
+  };
+};

--- a/src/pages/Live.tsx
+++ b/src/pages/Live.tsx
@@ -337,8 +337,8 @@ const Live = () => {
                             <TableHead className="text-primary-foreground font-bold text-center w-[80px]">
                               {isStroke ? 'Dif Par' : 'Total'}
                             </TableHead>
-                            <TableHead className="text-primary-foreground font-bold text-center w-[80px]">Hoy</TableHead>
                             <TableHead className="text-primary-foreground font-bold text-center w-[60px]">Thru</TableHead>
+                            <TableHead className="text-primary-foreground font-bold text-center w-[80px]">Hoy</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -371,17 +371,17 @@ const Live = () => {
                                 {isStroke ? formatDifPar(player.score) : player.score}
                               </TableCell>
 
+                              {/* Holes completed — shows "F" when finished */}
+                              <TableCell className={`text-center text-sm ${isPlayerFinished(player.thru) ? 'font-bold text-green-700' : ''}`}>
+                                {formatThru(player.thru)}
+                              </TableCell>
+
                               {/* Today's score */}
                               <TableCell className={`text-center text-sm ${isStroke ? getStrokeScoreClass(player.todayScore ?? 0) : ''}`}>
                                 {isStroke
                                   ? formatDifPar(player.todayScore ?? 0)
                                   : (player.todayScore ?? '-')
                                 }
-                              </TableCell>
-
-                              {/* Holes completed — shows "F" when finished */}
-                              <TableCell className={`text-center text-sm ${isPlayerFinished(player.thru) ? 'font-bold text-green-700' : ''}`}>
-                                {formatThru(player.thru)}
                               </TableCell>
                             </TableRow>
                           ))}

--- a/src/pages/Live.tsx
+++ b/src/pages/Live.tsx
@@ -9,9 +9,12 @@
  * 
  * Flow: Category cards → Leaderboard table
  * Auto-refreshes every 10 seconds
+ * 
+ * Clickable scores: clicking a player's main score (Dif Par / Total)
+ * expands their live scorecard fetched from live_tarjeta.php
  */
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, Fragment } from 'react';
 import Layout from '@/components/layout/Layout';
 import PageHero from '@/components/shared/PageHero';
 import { Card, CardContent } from '@/components/ui/card';
@@ -22,6 +25,9 @@ import { useQuery, useQueries } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/apiClient';
 import { getLiveScoringUrl, POLL_LIVE } from '@/config/api';
 import { useSiteConfig, type LiveScoringEntry } from '@/hooks/useSiteConfig';
+import { fetchLiveScorecardFromApi } from '@/hooks/useResultadosData';
+import type { RoundScorecard } from '@/data/resultadosData';
+import ScorecardRow from '@/components/resultados/ScorecardRow';
 import liveHero from '@/assets/live-hero.jpg';
 import {
   Table,
@@ -135,6 +141,11 @@ const Live = () => {
   /** Currently selected category entry */
   const [selected, setSelected] = useState<LiveScoringEntry | null>(null);
 
+  /** Expanded scorecard state: playerId or null */
+  const [expandedPlayerId, setExpandedPlayerId] = useState<string | null>(null);
+  const [scorecardData, setScorecardData] = useState<RoundScorecard | null>(null);
+  const [scorecardLoading, setScorecardLoading] = useState(false);
+
   /** Site config with live scoring entries */
   const { data: siteConfig, isLoading: loadingConfig } = useSiteConfig();
 
@@ -178,6 +189,48 @@ const Live = () => {
 
   /** Whether it's stroke play */
   const isStroke = leaderboard?.type === 'stroke' || selected?.tipo === 'stroke';
+
+  /**
+   * Handle click on a player's main score to show/hide their live scorecard
+   * Fetches data from live_tarjeta.php
+   */
+  const handleScoreClick = async (player: LivePlayer) => {
+    // Toggle off if already expanded
+    if (expandedPlayerId === player.playerId) {
+      setExpandedPlayerId(null);
+      setScorecardData(null);
+      return;
+    }
+
+    // Only show scorecard if player has started (thru > 0)
+    if (player.thru <= 0) return;
+
+    setExpandedPlayerId(player.playerId);
+    setScorecardData(null);
+    setScorecardLoading(true);
+
+    try {
+      const tipo = selected?.tipo || (isStroke ? 'stroke' : 'stableford');
+      const scoringType = selected?.gross === 1 ? 'GROSS' : 'NETO';
+      const scorecard = await fetchLiveScorecardFromApi(player.playerId, tipo, scoringType);
+      setScorecardData(scorecard);
+    } catch (err) {
+      console.error('Failed to fetch live scorecard:', err);
+      setScorecardData(null);
+    } finally {
+      setScorecardLoading(false);
+    }
+  };
+
+  /** Reset scorecard state when changing category */
+  const handleSelectCategory = (entry: LiveScoringEntry) => {
+    setExpandedPlayerId(null);
+    setScorecardData(null);
+    setSelected(entry);
+  };
+
+  /** Total number of columns in the leaderboard table */
+  const totalCols = 6;
 
   return (
     <Layout>
@@ -236,7 +289,7 @@ const Live = () => {
                           ? 'opacity-60 cursor-default border-muted'
                           : 'hover:border-primary/50 hover:shadow-lg cursor-pointer group'
                       }`}
-                      onClick={() => !isCompleted && setSelected(entry)}
+                      onClick={() => !isCompleted && handleSelectCategory(entry)}
                     >
                       <CardContent className="p-6 text-center">
                         <div className={`w-14 h-14 rounded-full mx-auto mb-4 flex items-center justify-center transition-colors ${
@@ -291,7 +344,7 @@ const Live = () => {
             <>
               <Button
                 variant="ghost"
-                onClick={() => setSelected(null)}
+                onClick={() => { setSelected(null); setExpandedPlayerId(null); setScorecardData(null); }}
                 className="mb-6 gap-2 bg-primary/10 hover:bg-primary/20"
               >
                 <ArrowLeft className="h-4 w-4" />
@@ -343,47 +396,82 @@ const Live = () => {
                         </TableHeader>
                         <TableBody>
                           {leaderboard.players.map((player) => (
-                            <TableRow key={player.playerId} className="bg-white hover:bg-muted/30">
-                              {/* Position */}
-                              <TableCell className="text-center font-bold">
-                                {player.position}
-                              </TableCell>
+                            <Fragment key={player.playerId}>
+                              <TableRow className="bg-white hover:bg-muted/30">
+                                {/* Position */}
+                                <TableCell className="text-center font-bold">
+                                  {player.position}
+                                </TableCell>
 
-                              {/* Club logo - own column */}
-                              <TableCell className="w-16 min-w-16 p-1 text-center align-middle">
-                                {player.clubLogo ? (
-                                  <img
-                                    src={player.clubLogo}
-                                    alt={player.club}
-                                    className="w-14 h-9 object-contain rounded inline-block mx-auto"
-                                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                                {/* Club logo */}
+                                <TableCell className="w-16 min-w-16 p-1 text-center align-middle">
+                                  {player.clubLogo ? (
+                                    <img
+                                      src={player.clubLogo}
+                                      alt={player.club}
+                                      className="w-14 h-9 object-contain rounded inline-block mx-auto"
+                                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                                    />
+                                  ) : null}
+                                </TableCell>
+
+                                {/* Player name */}
+                                <TableCell className="font-medium">
+                                  {player.name}
+                                </TableCell>
+
+                                {/* Main score — clickable to expand live scorecard */}
+                                <TableCell className="text-center p-0">
+                                  {player.thru > 0 ? (
+                                    <button
+                                      onClick={() => handleScoreClick(player)}
+                                      className={`w-full py-3 px-2 transition-colors cursor-pointer hover:bg-primary/10 hover:text-primary ${
+                                        isStroke ? getStrokeScoreClass(player.score) : 'font-bold'
+                                      } ${expandedPlayerId === player.playerId ? 'bg-primary/15 text-primary font-bold underline underline-offset-2' : ''}`}
+                                      title="Ver tarjeta en vivo"
+                                    >
+                                      {isStroke ? formatDifPar(player.score) : player.score}
+                                    </button>
+                                  ) : (
+                                    <span className={`py-3 px-2 inline-block ${isStroke ? getStrokeScoreClass(player.score) : 'font-bold'}`}>
+                                      {isStroke ? formatDifPar(player.score) : player.score}
+                                    </span>
+                                  )}
+                                </TableCell>
+
+                                {/* Holes completed — shows "F" when finished */}
+                                <TableCell className={`text-center text-sm ${isPlayerFinished(player.thru) ? 'font-bold text-green-700' : ''}`}>
+                                  {formatThru(player.thru)}
+                                </TableCell>
+
+                                {/* Today's score */}
+                                <TableCell className={`text-center text-sm ${isStroke ? getStrokeScoreClass(player.todayScore ?? 0) : ''}`}>
+                                  {isStroke
+                                    ? formatDifPar(player.todayScore ?? 0)
+                                    : (player.todayScore ?? '-')
+                                  }
+                                </TableCell>
+                              </TableRow>
+
+                              {/* Expanded live scorecard row */}
+                              {expandedPlayerId === player.playerId && (
+                                scorecardLoading ? (
+                                  <TableRow className="bg-white hover:bg-white">
+                                    <TableCell colSpan={totalCols} className="text-center py-6 text-muted-foreground">
+                                      Cargando tarjeta...
+                                    </TableCell>
+                                  </TableRow>
+                                ) : scorecardData ? (
+                                  <ScorecardRow
+                                    scorecard={scorecardData}
+                                    playerName={player.name}
+                                    roundLabel="En Vivo"
+                                    onClose={() => { setExpandedPlayerId(null); setScorecardData(null); }}
+                                    colSpan={totalCols}
                                   />
-                                ) : null}
-                              </TableCell>
-
-                              {/* Player name */}
-                              <TableCell className="font-medium">
-                                {player.name}
-                              </TableCell>
-
-                              {/* Main score: difpar for stroke, SA total for stableford */}
-                              <TableCell className={`text-center ${isStroke ? getStrokeScoreClass(player.score) : 'font-bold'}`}>
-                                {isStroke ? formatDifPar(player.score) : player.score}
-                              </TableCell>
-
-                              {/* Holes completed — shows "F" when finished */}
-                              <TableCell className={`text-center text-sm ${isPlayerFinished(player.thru) ? 'font-bold text-green-700' : ''}`}>
-                                {formatThru(player.thru)}
-                              </TableCell>
-
-                              {/* Today's score */}
-                              <TableCell className={`text-center text-sm ${isStroke ? getStrokeScoreClass(player.todayScore ?? 0) : ''}`}>
-                                {isStroke
-                                  ? formatDifPar(player.todayScore ?? 0)
-                                  : (player.todayScore ?? '-')
-                                }
-                              </TableCell>
-                            </TableRow>
+                                ) : null
+                              )}
+                            </Fragment>
                           ))}
                         </TableBody>
                       </Table>


### PR DESCRIPTION
## What
Solves live page scoring table order and enables scorecards for live players. additionally, separates live values to resultados from being added when scorecard is yet to be completed.

## Why
chore (resolving dif vs total value conflict), feature (enables scorecards for players) and bugfix (scores added to resultados)

## Changes
- visibility for live as structure and SC

## Related Issues
Closes #32 
Closes #17 

## How to test
- review live page. check column order.
- review live page with ongoing results. click on score to display SC. 
- review results page, should only add closed SC's.


## Notes (optional)
