### PR TITLE
Feature/scoring medal winners cutoff 18

### DIFF
--- a/server/api/resultados_jug.php
+++ b/server/api/resultados_jug.php
@@ -9,6 +9,10 @@
  * to avoid counting partial live scoring data.
  * Per-day functions (f_score_dia_sax/sox) already use v_resultar
  * which filters by statlsc = 1.
+ *
+ * Returns two arrays: 'players' (estatus=NORMAL) and 'cutPlayers'
+ * (non-NORMAL: NO SHOW, RETIRO, DESCALIFICADO, etc.)
+ * Also returns 'medalCount' from categorias.numjugprem for dynamic medal assignment.
  */
 require_once 'config.php';
 
@@ -23,15 +27,16 @@ $gross    = optional_param('gross', '0');
 $cid = esc($conn, $catid);
 $tid = esc($conn, $torneoid);
 
-// ============= Get category info =============
+// ============= Get category info (includes numjugprem for medal count) =============
 $sql = "SELECT a.categoria_id, a.categoria, a.abreviatura, a.sistema, a.formato,
                a.estilo, a.gross, a.porcentaje, a.salida, a.hoyosajugar,
+               IFNULL(a.numjugprem, 3) as numjugprem,
                COUNT(b.id) as playerCount
         FROM categorias a
         JOIN jugadores b ON (a.categoria_id = b.categoriaid)
         WHERE a.categoria_id = $cid
         GROUP BY a.categoria_id, a.categoria, a.abreviatura, a.sistema, a.formato,
-                 a.estilo, a.gross, a.porcentaje, a.salida, a.hoyosajugar";
+                 a.estilo, a.gross, a.porcentaje, a.salida, a.hoyosajugar, a.numjugprem";
 
 $catInfo = query_one($conn, $sql);
 debug_log_query('Category info', $sql);
@@ -41,6 +46,7 @@ if (!$catInfo) {
 
 $sistema = strtoupper($catInfo['sistema']);
 $formato = strtoupper($catInfo['formato']);
+$medalCount = (int)$catInfo['numjugprem'];
 
 // ============= Get play dates =============
 $sql = "SELECT fecha FROM caljuego
@@ -62,8 +68,6 @@ $sql = "SELECT b.campoid, b.salidaid, rating, slope, tee, parcampo
 $courseInfo = query_one($conn, $sql);
 
 // ============= Inline subquery helpers for closed-card totals =============
-// These replace the DB functions (f_torneosa, f_torneoso, etc.) which do NOT
-// filter by statlsc, causing partial live scoring data to inflate totals.
 
 /** Sum SA (neto/stableford points) from CLOSED cards only */
 $closedSA  = "(SELECT IFNULL(SUM(t.SA), 0) FROM tarjetas t WHERE t.jugadorid = j.id AND t.torneoid = j.torneoid AND t.statlsc = 1)";
@@ -74,20 +78,41 @@ $closedSO  = "(SELECT IFNULL(SUM(t.SO), 0) FROM tarjetas t WHERE t.jugadorid = j
 /** Sum totstbgross (stableford gross points) from CLOSED cards only */
 $closedSTBGross = "(SELECT IFNULL(SUM(t.totstbgross), 0) FROM tarjetas t WHERE t.jugadorid = j.id AND t.torneoid = j.torneoid AND t.statlsc = 1)";
 
-// ============= Build main results query =============
+// ============= Helper: map estatus to short code =============
+/**
+ * Maps player estatus to a display code:
+ * NORMAL → null (active player), NO SHOW/SHOW-NO → S, 
+ * RETIRO/ABANDONO → R, DESCALIFICADO/DQ → D, other → D
+ */
+function mapEstatus($estatus) {
+    $e = strtoupper(trim($estatus));
+    if ($e === 'NORMAL') return null;
+    if ($e === 'NO SHOW' || $e === 'SHOW-NO' || $e === 'NO-SHOW') return 'S';
+    if ($e === 'RETIRO' || $e === 'ABANDONO') return 'R';
+    if ($e === 'DESCALIFICADO' || $e === 'DQ') return 'D';
+    return 'D'; // default for unknown non-NORMAL statuses
+}
+
+/** Map status code to descriptive label */
+function statusLabel($code) {
+    if ($code === 'S') return 'No Show';
+    if ($code === 'R') return 'Retiro';
+    if ($code === 'D') return 'Descalificado';
+    return '';
+}
+
+// ============= Build main results query (NORMAL players) =============
 $players = [];
 
 if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
 
     if ($gross == '1') {
-        // GROSS results — only closed scorecards in totals
         $sql = "SELECT j.id AS jugadorid, j.numjugador,
                        CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
                        $closedSO as so,
                        $closedSA as sa,
                        IFNULL(j.muertesubita, 0) as muertesubita";
 
-        // Per-day scores (already filtered via v_resultar → statlsc = 1)
         foreach ($dias as $i => $fecha) {
             $sql .= ", f_score_dia_sox(j.id, '$fecha') as d{$i}";
         }
@@ -102,25 +127,20 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
                    AND j.estatus = 'NORMAL'
                  ORDER BY $closedSO ASC";
 
-        // Priority tiebreaker: muerte subita (highest wins, 0/NULL = no value)
         $sql .= ", IFNULL(j.muertesubita, 0) DESC";
-        // Tiebreaker: best last round score ASC (lowest wins in Stroke Play)
         $lastDayGross = end($dias);
         if ($lastDayGross) {
             $sql .= ", f_score_dia_sox(j.id, '$lastDayGross') ASC";
         }
-        // Secondary tiebreakers (9-6-3-1 system)
         $sql .= ", u.c1 ASC, u.c2 ASC, u.c3 ASC";
 
     } else {
-        // NETO results — only closed scorecards in totals
         $sql = "SELECT j.id AS jugadorid, j.numjugador,
                        CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
                        $closedSA as sa,
                        $closedSO as so,
                        IFNULL(j.muertesubita, 0) as muertesubita";
 
-        // Per-day scores (already filtered via v_resultar → statlsc = 1)
         foreach ($dias as $i => $fecha) {
             $sql .= ", f_score_dia_sax(j.id, '$fecha') as d{$i}";
         }
@@ -136,28 +156,23 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
                    AND j.campgross = 0
                  ORDER BY $closedSA ASC";
 
-        // Priority tiebreaker: muerte subita (highest wins, 0/NULL = no value)
         $sql .= ", IFNULL(j.muertesubita, 0) DESC";
-        // Tiebreaker: best last round score ASC (lowest wins in Stroke Play)
         $lastDayNeto = end($dias);
         if ($lastDayNeto) {
             $sql .= ", f_score_dia_sax(j.id, '$lastDayNeto') ASC";
         }
-        // Secondary tiebreakers (9-6-3-1 system)
         $sql .= ", u.c1 ASC, u.c2 ASC, u.c3 ASC";
     }
 
 } elseif ($sistema === 'STABLEFORD') {
 
     if ($gross == '1') {
-        // Stableford GROSS — only closed scorecards in totals
         $sql = "SELECT j.id AS jugadorid, j.numjugador,
                        CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
                        $closedSTBGross as sa,
                        $closedSO as so,
                        IFNULL(j.muertesubita, 0) as muertesubita";
 
-        // Per-day scores (already filtered via v_resultar → statlsc = 1)
         foreach ($dias as $i => $fecha) {
             $sql .= ", f_score_dia_sox(j.id, '$fecha') as d{$i}";
         }
@@ -172,24 +187,19 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
                    AND j.estatus = 'NORMAL'
                  ORDER BY $closedSTBGross DESC";
 
-        // Priority tiebreaker: muerte subita (highest wins, 0/NULL = no value)
         $sql .= ", IFNULL(j.muertesubita, 0) DESC";
-        // Tiebreaker: last round score DESC (highest last round wins)
         $lastDayGross = end($dias);
         if ($lastDayGross) {
             $sql .= ", f_score_dia_sox(j.id, '$lastDayGross') DESC";
         }
-        // Secondary tiebreakers
         $sql .= ", u.c1 DESC, u.c2 DESC, u.c3 DESC";
     } else {
-        // Stableford NETO — only closed scorecards in totals
         $sql = "SELECT j.id AS jugadorid, j.numjugador,
                        CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
                        $closedSA as sa,
                        $closedSO as so,
                        IFNULL(j.muertesubita, 0) as muertesubita";
 
-        // Per-day scores (already filtered via v_resultar → statlsc = 1)
         foreach ($dias as $i => $fecha) {
             $sql .= ", f_score_dia_sax(j.id, '$fecha') as d{$i}";
         }
@@ -205,14 +215,11 @@ if ($sistema === 'STROKE PLAY' || $sistema === 'STROKE') {
                    AND j.campgross = 0
                  ORDER BY $closedSA DESC";
 
-        // Priority tiebreaker: muerte subita (highest wins, 0/NULL = no value)
         $sql .= ", IFNULL(j.muertesubita, 0) DESC";
-        // Tiebreaker: last round score DESC (highest last round wins)
         $lastDay = end($dias);
         if ($lastDay) {
             $sql .= ", f_score_dia_sax(j.id, '$lastDay') DESC";
         }
-        // Secondary tiebreakers
         $sql .= ", u.c1 DESC, u.c2 DESC, u.c3 DESC";
     }
 }
@@ -235,13 +242,40 @@ foreach ($rows as $row) {
         'totalSA'   => (int)($row['sa'] ?? 0)
     ];
 
-    // Add per-day scores
     foreach ($dias as $i => $fecha) {
         $val = $row["d{$i}"] ?? null;
         $player["r{$i}"] = $val !== null && $val != 0 ? (int)$val : null;
     }
 
     $players[] = $player;
+}
+
+// ============= Fetch non-NORMAL players (cut players: NO SHOW, RETIRO, DQ, etc.) =============
+$cutPlayers = [];
+$cutSql = "SELECT j.id AS jugadorid, j.numjugador,
+                  CONCAT(j.nombre, ' ', j.apellido) as jugador, j.estatus,
+                  c.abr, c.logo
+           FROM jugadores j
+           JOIN clubs c ON (j.clubid = c.id)
+           WHERE j.categoriaid = $cid
+             AND j.torneoid = $tid
+             AND j.estatus != 'NORMAL'
+           ORDER BY j.estatus ASC, j.apellido ASC";
+
+debug_log_query('Cut players query', $cutSql);
+$cutRows = query_all($conn, $cutSql);
+
+foreach ($cutRows as $row) {
+    $statusCode = mapEstatus($row['estatus']);
+    $cutPlayers[] = [
+        'playerId'    => $row['jugadorid'],
+        'number'      => $row['numjugador'],
+        'name'        => $row['jugador'],
+        'club'        => $row['abr'],
+        'clubLogo'    => $row['logo'] ? $LOGOS_BASE_URL . $row['logo'] : '',
+        'statusCode'  => $statusCode ?? 'D',
+        'statusLabel' => statusLabel($statusCode ?? 'D'),
+    ];
 }
 
 json_response([
@@ -251,6 +285,7 @@ json_response([
     'system'       => $catInfo['sistema'],
     'format'       => $catInfo['formato'],
     'gross'        => (int)$gross,
+    'medalCount'   => $medalCount,
     'course'       => $courseInfo ? [
         'rating'   => (float)($courseInfo['rating'] ?? 0),
         'slope'    => (int)($courseInfo['slope'] ?? 0),
@@ -258,5 +293,6 @@ json_response([
         'par'      => (int)($courseInfo['parcampo'] ?? 72)
     ] : null,
     'days'         => array_values($dias),
-    'players'      => $players
+    'players'      => $players,
+    'cutPlayers'   => $cutPlayers,
 ]);

--- a/src/data/resultadosData.ts
+++ b/src/data/resultadosData.ts
@@ -81,6 +81,10 @@ export interface ResultCategory {
   system?: string;
   /** Round dates from the API, e.g. ["2026-02-18", "2026-02-19"] */
   days?: string[];
+  /** Number of medal winners from DB (numjugprem) */
+  medalCount?: number;
+  /** Players who did not complete (NO SHOW, RETIRO, DQ) */
+  cutPlayers?: CutPlayer[];
   scoringTypes: CategoryScoring[];
 }
 

--- a/src/data/resultadosData.ts
+++ b/src/data/resultadosData.ts
@@ -51,6 +51,19 @@ export interface PlayerResult {
   handicapIndex?: number;
 }
 
+/** Player who did not complete the tournament (NO SHOW, RETIRO, DQ) */
+export interface CutPlayer {
+  playerId: string;
+  number: string;
+  name: string;
+  club: string;
+  clubLogo?: string;
+  /** Status code: S = No Show, R = Retiro, D = Descalificado */
+  statusCode: 'S' | 'R' | 'D';
+  /** Human-readable status label */
+  statusLabel: string;
+}
+
 export interface CategoryScoring {
   scoringType: ScoringType;
   /** Which scorecard format to use when expanding rounds */

--- a/src/hooks/useResultadosData.ts
+++ b/src/hooks/useResultadosData.ts
@@ -7,7 +7,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '@/lib/apiClient';
 import { getResultadosUrl, getResultadosCategoryUrl, getResultadosTarjetaUrl, getLiveTarjetaUrl, POLL_ACTIVE } from '@/config/api';
-import type { ResultCategory, RoundScorecard, HoleScore, ScorecardType } from '@/data/resultadosData';
+import type { ResultCategory, RoundScorecard, HoleScore, ScorecardType, CutPlayer } from '@/data/resultadosData';
 
 // ============= All Results =============
 
@@ -135,12 +135,25 @@ export const useCategoryResults = (categoryId: string | null, enabled = true, sc
               })),
             }];
 
+      // Map cut players (non-NORMAL status)
+      const cutPlayers: CutPlayer[] = (raw.cutPlayers || []).map((cp: any) => ({
+        playerId: cp.playerId || '',
+        number: cp.number || '',
+        name: cp.name || '',
+        club: cp.club || '',
+        clubLogo: cp.clubLogo || '',
+        statusCode: cp.statusCode || 'D',
+        statusLabel: cp.statusLabel || 'Descalificado',
+      }));
+
       return {
         categoryId: raw.categoryId || categoryId!,
         categoryName: raw.categoryName || '',
         shortName: raw.shortName || '',
         system: raw.system || '',
         days: raw.days || [],
+        medalCount: raw.medalCount ?? 3,
+        cutPlayers,
         scoringTypes,
       } as ResultCategory;
     },

--- a/src/pages/Resultados.tsx
+++ b/src/pages/Resultados.tsx
@@ -2,7 +2,8 @@
  * Resultados Page
  * Displays tournament results by category and scoring type
  * Supports expandable scorecards when clicking on round scores
- * Data fetched from resultados.php via React Query hooks
+ * Shows cut line separator and non-NORMAL players (S/R/D) below
+ * Medal count is dynamic based on numjugprem from DB
  */
 
 import Layout from '@/components/layout/Layout';
@@ -20,25 +21,42 @@ import type {
   ScorecardType,
   PlayerResult,
   RoundScorecard,
+  CutPlayer,
 } from '@/data/resultadosData';
 import ScorecardRow from '@/components/resultados/ScorecardRow';
 
 // ============= Helper Functions =============
 
-/** Returns medal color class based on position */
-const getPositionStyle = (position: number) => {
+/**
+ * Returns medal color class based on position
+ * Gold (1st), Silver (2nd), Bronze (3rd+)
+ */
+const getMedalStyle = (position: number) => {
   if (position === 1) return 'text-yellow-500';
   if (position === 2) return 'text-gray-400';
-  if (position === 3) return 'text-amber-600';
-  return '';
+  return 'text-amber-600'; // bronze for 3rd and beyond
 };
 
-/** Returns medal icon for top 3 positions */
-const getPositionIcon = (position: number) => {
-  if (position <= 3) {
-    return <Medal className={`h-5 w-5 ${getPositionStyle(position)}`} />;
+/**
+ * Returns medal icon if position is within medal count, otherwise null
+ * @param position - Player's ranking position
+ * @param medalCount - Number of medal winners from DB (numjugprem)
+ */
+const getPositionIcon = (position: number, medalCount: number) => {
+  if (position <= medalCount) {
+    return <Medal className={`h-5 w-5 ${getMedalStyle(position)}`} />;
   }
   return null;
+};
+
+/**
+ * Returns status badge color classes based on status code
+ * S = No Show (muted), R = Retiro (warning), D = Descalificado (destructive)
+ */
+const getStatusBadgeClasses = (code: string) => {
+  if (code === 'S') return 'bg-muted text-muted-foreground';
+  if (code === 'R') return 'bg-amber-100 text-amber-800';
+  return 'bg-red-100 text-red-800'; // D
 };
 
 // ============= Component =============
@@ -65,9 +83,14 @@ const Resultados = () => {
   /** Find the selected category object from the list (metadata only) */
   const selectedCategory = categories.find(c => c.categoryId === selectedCategoryId) || null;
 
+  /** Medal count from API (defaults to 3) */
+  const medalCount = categoryDetail?.medalCount ?? 3;
+
+  /** Cut players (non-NORMAL status) from API */
+  const cutPlayers: CutPlayer[] = categoryDetail?.cutPlayers || [];
+
   /** Get players for the selected scoring type - MUST use categoryDetail for full data */
   const players: PlayerResult[] = (() => {
-    // only use categoryDetail which is fetched from resultados_jug.php and has full data
     if (!categoryDetail || !selectedScoringType) return [];
     const scoring = categoryDetail.scoringTypes?.find(s => s.scoringType === selectedScoringType);
     return scoring?.players || [];
@@ -78,7 +101,6 @@ const Resultados = () => {
     setSelectedCategoryId(category.categoryId);
     setExpandedScorecard(null);
     setScorecardData(null);
-    // Auto-select if only one scoring type available
     if (category.scoringTypes.length === 1) {
       setSelectedScoringType(category.scoringTypes[0].scoringType as ScoringType);
     } else {
@@ -98,7 +120,6 @@ const Resultados = () => {
     setExpandedScorecard(null);
     setScorecardData(null);
     if (selectedScoringType) {
-      // if category only has one scoring type, go back to category list
       const cat = categories.find(c => c.categoryId === selectedCategoryId);
       if (cat && cat.scoringTypes.length <= 1) {
         setSelectedCategoryId(null);
@@ -127,16 +148,14 @@ const Resultados = () => {
     
     if (roundScore === undefined || roundScore === null) return;
 
-    // Toggle off if already expanded
     if (expandedScorecard === key) {
       setExpandedScorecard(null);
       setScorecardData(null);
       return;
     }
 
-    // Get the date for this round from the category detail days array
     const days = categoryDetail?.days || [];
-    const fecha = days[round - 1]; // R1 → days[0], R2 → days[1], etc.
+    const fecha = days[round - 1];
 
     if (!fecha || !categoryDetail) {
       console.warn('No date found for round', round, 'days:', days);
@@ -145,7 +164,6 @@ const Resultados = () => {
       return;
     }
 
-    // Fetch scorecard from API
     setExpandedScorecard(key);
     setScorecardData(null);
     setScorecardLoading(true);
@@ -167,6 +185,9 @@ const Resultados = () => {
       setScorecardLoading(false);
     }
   };
+
+  /** Total columns count for colSpan calculations */
+  const totalCols = 3 + (categoryDetail?.days?.length || 0) + 1;
 
   const isLoading = loadingCats || loadingDetail;
 
@@ -305,18 +326,19 @@ const Resultados = () => {
                         </TableHeader>
                         <TableBody>
                           {players.length > 0 ? (
-                            players.map((player, idx) => (
+                            players.map((player) => (
                               <Fragment key={player.id}>
                                 <TableRow className="bg-white hover:bg-white">
+                                  {/* Position with dynamic medal */}
                                   <TableCell className="font-semibold">
                                     <div className="flex items-center gap-2">
-                                      {getPositionIcon(player.position)}
-                                      <span className={getPositionStyle(player.position)}>
+                                      {getPositionIcon(player.position, medalCount)}
+                                      <span className={player.position <= medalCount ? getMedalStyle(player.position) : ''}>
                                         {player.position}
                                       </span>
                                     </div>
                                   </TableCell>
-                                  {/* Club Logo column - always left of name */}
+                                  {/* Club Logo */}
                                   <TableCell className="p-1 text-center align-middle">
                                     {player.clubLogo ? (
                                       <img
@@ -365,7 +387,7 @@ const Resultados = () => {
                                 {expandedScorecard?.startsWith(`${player.id}-`) && (
                                   scorecardLoading ? (
                                     <TableRow className="bg-white hover:bg-white">
-                                      <TableCell colSpan={3 + (categoryDetail?.days?.length || 0) + 1} className="text-center py-6 text-muted-foreground">
+                                      <TableCell colSpan={totalCols} className="text-center py-6 text-muted-foreground">
                                         Cargando tarjeta...
                                       </TableCell>
                                     </TableRow>
@@ -375,7 +397,7 @@ const Resultados = () => {
                                       playerName={player.name}
                                       roundLabel={`Ronda ${expandedScorecard.split('-').pop()}`}
                                       onClose={() => { setExpandedScorecard(null); setScorecardData(null); }}
-                                      colSpan={3 + (categoryDetail?.days?.length || 0) + 1}
+                                      colSpan={totalCols}
                                     />
                                   ) : null
                                 )}
@@ -383,10 +405,63 @@ const Resultados = () => {
                             ))
                           ) : (
                             <TableRow>
-                              <TableCell colSpan={3 + (categoryDetail?.days?.length || 0) + 1} className="text-center text-muted-foreground py-8">
+                              <TableCell colSpan={totalCols} className="text-center text-muted-foreground py-8">
                                 No hay resultados disponibles
                               </TableCell>
                             </TableRow>
+                          )}
+
+                          {/* ============= CUT LINE SEPARATOR ============= */}
+                          {cutPlayers.length > 0 && (
+                            <>
+                              {/* Visual cut line: grey separator row */}
+                              <TableRow className="bg-muted/60 hover:bg-muted/60 border-t-2 border-b-2 border-border">
+                                <TableCell colSpan={totalCols} className="text-center py-3">
+                                  <span className="text-sm font-semibold text-muted-foreground tracking-wide uppercase">
+                                    — No completaron —
+                                  </span>
+                                </TableCell>
+                              </TableRow>
+
+                              {/* Non-NORMAL players (S/R/D) */}
+                              {cutPlayers.map((cp) => (
+                                <TableRow key={cp.playerId} className="bg-muted/20 hover:bg-muted/30">
+                                  {/* Status code instead of position */}
+                                  <TableCell className="font-semibold text-center">
+                                    <span className={`inline-block px-2 py-0.5 rounded text-xs font-bold ${getStatusBadgeClasses(cp.statusCode)}`}>
+                                      {cp.statusCode}
+                                    </span>
+                                  </TableCell>
+                                  {/* Club Logo */}
+                                  <TableCell className="p-1 text-center align-middle">
+                                    {cp.clubLogo ? (
+                                      <img
+                                        src={cp.clubLogo}
+                                        alt="Club"
+                                        className="w-auto object-contain rounded inline-block opacity-60"
+                                        style={{ height: '2.25rem' }}
+                                        onError={(e) => {
+                                          (e.target as HTMLImageElement).src = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="%23166534" rx="4"/><text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="9" font-family="sans-serif">Club</text></svg>')}`;
+                                        }}
+                                      />
+                                    ) : (
+                                      <span className="text-xs text-muted-foreground">{cp.club}</span>
+                                    )}
+                                  </TableCell>
+                                  {/* Player name + status label */}
+                                  <TableCell className="font-medium text-muted-foreground">
+                                    {cp.name}
+                                    <span className="ml-2 text-xs text-muted-foreground/70">({cp.statusLabel})</span>
+                                  </TableCell>
+                                  {/* Empty round cells */}
+                                  {(categoryDetail?.days || []).map((_, i) => (
+                                    <TableCell key={i} className="text-center text-muted-foreground">—</TableCell>
+                                  ))}
+                                  {/* Empty total */}
+                                  <TableCell className="text-center text-muted-foreground font-medium">—</TableCell>
+                                </TableRow>
+                              ))}
+                            </>
                           )}
                         </TableBody>
                       </Table>


### PR DESCRIPTION
## What
Enables resultados to correctly display winners for each category as well as cutoffs due to issues regarding specific players such as DQ's or no-shows.

## Why
This is required due to the differences between tournaments and such requirements like winners per category vary per tournament. For example, 5 winners might be chosen for juniors while only one for pro categories. 
features exclusively to display DQ'd players, dynamically set winners, and winner icons per category given winner count.

## ChangesDisplay cut line
- Show players below cut if status != NORMAL
- Configure number of medal winners (gross/neto)
- Support dynamic number of winners (3–5+)

## Related Issues
Closes #18 

## How to test
- set a random number of winners to an old tournament
- check resultados tables for given category
- set one of those winners to estatus "DQSS" and "DQ", "RETIRADO" AND "NO SHOW"

## Notes (optional)
