### PR TITLE
Feature/prize winner descriptions 19

### DIFF
--- a/server/api/competencias.php
+++ b/server/api/competencias.php
@@ -83,7 +83,7 @@ if ($tipo === '' || $tipo === 'oyes') {
     
     if ($row && (int)$row['cnt'] > 0) {
         // Get groups (prizes)
-        $sql = "SELECT DISTINCT premio as id, CONCAT('Premio ', premio) as name #hoyo
+        $sql = "SELECT DISTINCT premio as id, descripcion as name
                 FROM premiosjug
                 WHERE torneoid = $tid
                 ORDER BY premio ASC";

--- a/src/components/competencias/CompetenciasGroupCard.tsx
+++ b/src/components/competencias/CompetenciasGroupCard.tsx
@@ -33,9 +33,9 @@ const CompetenciasGroupCard = ({ group, onClick }: CompetenciasGroupCardProps) =
       onClick={onClick}
     >
       <CardContent className="p-5">
-        {/* Group name */}
+        {/* Group description or name */}
         <h3 className="font-bold text-foreground text-lg mb-3 group-hover:text-primary transition-colors">
-          {group.name}
+          {group.description || group.name}
         </h3>
         
         {/* Stats row */}

--- a/src/components/competencias/CompetenciasTable.tsx
+++ b/src/components/competencias/CompetenciasTable.tsx
@@ -85,7 +85,7 @@ const CompetenciasTable = ({ players, columns }: CompetenciasTableProps) => {
             players.map((player) => (
               <TableRow 
                 key={player.id}
-                className="bg-white hover:bg-muted/30"
+                className="bg-white"
               >
                 {columns.map((col) => (
                   <TableCell 

--- a/src/components/competencias/CompetenciasTable.tsx
+++ b/src/components/competencias/CompetenciasTable.tsx
@@ -2,13 +2,10 @@
  * CompetenciasTable Component
  * Displays results table for a competition group
  * Supports dynamic columns based on competition type
- * Includes search functionality to find players by name
+ * No search — search lives on the Premios page
  */
 
-import { useState, useMemo } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Input } from '@/components/ui/input';
-import { Medal, Search, X } from 'lucide-react';
 import { CompetenciaPlayer, ColumnConfig } from '@/data/competenciasConfig';
 
 // ============= Types =============
@@ -54,152 +51,89 @@ const getCellValue = (player: CompetenciaPlayer, key: string): unknown => {
   return player[key as keyof CompetenciaPlayer];
 };
 
-/** Normalize text for search (removes accents and lowercases) */
-const normalizeText = (text: string): string => {
-  return text
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
-};
-
 // ============= Component =============
 
 /**
  * CompetenciasTable
- * Renders a results table with dynamic columns and name search
+ * Renders a results table with dynamic columns
  */
 const CompetenciasTable = ({ players, columns }: CompetenciasTableProps) => {
-  // Search state
-  const [searchQuery, setSearchQuery] = useState('');
-
-  // Filter players based on search query
-  const filteredPlayers = useMemo(() => {
-    if (!searchQuery.trim()) return players;
-    
-    const normalizedQuery = normalizeText(searchQuery);
-    return players.filter(player => 
-      normalizeText(player.name).includes(normalizedQuery)
-    );
-  }, [players, searchQuery]);
-
-  // Clear search handler
-  const handleClearSearch = () => setSearchQuery('');
-
   return (
-    <div className="space-y-4">
-      {/* Search Input */}
-      <div className="px-4 pt-4">
-        <div className="relative max-w-sm">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            type="text"
-            placeholder="Buscar por nombre..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-10 pr-10"
-          />
-          {searchQuery && (
-            <button
-              onClick={handleClearSearch}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-              aria-label="Limpiar búsqueda"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          )}
-        </div>
-        {/* Search results count */}
-        {searchQuery && (
-          <p className="text-sm text-muted-foreground mt-2">
-            {filteredPlayers.length} resultado{filteredPlayers.length !== 1 ? 's' : ''} encontrado{filteredPlayers.length !== 1 ? 's' : ''}
-          </p>
-        )}
-      </div>
-
-      {/* Results Table */}
-      <div className="overflow-x-auto bg-white rounded-lg">
-        <Table>
-          {/* Table Header */}
-          <TableHeader>
-            <TableRow className="bg-primary hover:bg-primary">
-              {columns.map((col) => (
-                <TableHead 
-                  key={col.key}
-                  className={`text-primary-foreground font-bold ${
-                    col.align === 'center' ? 'text-center' : 
-                    col.align === 'right' ? 'text-right' : 'text-left'
-                  }`}
-                  style={{ width: col.width }}
-                >
-                  {col.label}
-                </TableHead>
-              ))}
-            </TableRow>
-          </TableHeader>
-          
-          {/* Table Body */}
-          <TableBody>
-            {filteredPlayers.length > 0 ? (
-              filteredPlayers.map((player, idx) => (
-                <TableRow 
-                  key={player.id}
-                  className={`bg-white hover:bg-muted/30 ${
-                    searchQuery && normalizeText(player.name).includes(normalizeText(searchQuery))
-                      ? 'ring-2 ring-primary/50 ring-inset'
-                      : ''
-                  }`}
-                >
-                  {columns.map((col) => (
-                    <TableCell 
-                      key={col.key}
-                      className={`${
-                        col.key === 'clubLogo' ? 'p-1 text-center align-middle' :
-                        col.align === 'center' ? 'text-center' : 
-                        col.align === 'right' ? 'text-right' : 'text-left'
-                      }`}
-                    >
-                      {/* Position column - number only */}
-                      {col.key === 'position' && col.format === 'medal' ? (
-                        <span>{player.position}</span>
-                      ) : col.key === 'clubLogo' ? (
-                        /* Club logo image - separate column, always left of name */
-                        player.clubLogo ? (
-                          <img
-                            src={player.clubLogo}
-                            alt="Club logo"
-                            className="w-auto object-contain rounded inline-block"
-                            style={{ height: '2.25rem' }}
-                            onError={(e) => {
-                              (e.target as HTMLImageElement).src = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="%23166534" rx="4"/><text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="9" font-family="sans-serif">Club</text></svg>')}`;
-                            }}
-                          />
-                        ) : (
-                          <span className="text-xs text-muted-foreground">{player.club}</span>
-                        )
+    <div className="overflow-x-auto bg-white rounded-lg">
+      <Table>
+        {/* Table Header */}
+        <TableHeader>
+          <TableRow className="bg-primary hover:bg-primary">
+            {columns.map((col) => (
+              <TableHead 
+                key={col.key}
+                className={`text-primary-foreground font-bold ${
+                  col.align === 'center' ? 'text-center' : 
+                  col.align === 'right' ? 'text-right' : 'text-left'
+                }`}
+                style={{ width: col.width }}
+              >
+                {col.label}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        
+        {/* Table Body */}
+        <TableBody>
+          {players.length > 0 ? (
+            players.map((player) => (
+              <TableRow 
+                key={player.id}
+                className="bg-white hover:bg-muted/30"
+              >
+                {columns.map((col) => (
+                  <TableCell 
+                    key={col.key}
+                    className={`${
+                      col.key === 'clubLogo' ? 'p-1 text-center align-middle' :
+                      col.align === 'center' ? 'text-center' : 
+                      col.align === 'right' ? 'text-right' : 'text-left'
+                    }`}
+                  >
+                    {/* Position column - number only */}
+                    {col.key === 'position' && col.format === 'medal' ? (
+                      <span>{player.position}</span>
+                    ) : col.key === 'clubLogo' ? (
+                      /* Club logo image */
+                      player.clubLogo ? (
+                        <img
+                          src={player.clubLogo}
+                          alt="Club logo"
+                          className="w-auto object-contain rounded inline-block"
+                          style={{ height: '2.25rem' }}
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).src = `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="%23166534" rx="4"/><text x="50%" y="54%" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="9" font-family="sans-serif">Club</text></svg>')}`;
+                          }}
+                        />
                       ) : (
-                        /* Standard cell rendering */
-                        formatValue(getCellValue(player, col.key), col.format)
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell 
-                  colSpan={columns.length} 
-                  className="text-center text-muted-foreground py-8"
-                >
-                  {searchQuery 
-                    ? `No se encontró "${searchQuery}"`
-                    : 'No hay resultados disponibles'
-                  }
-                </TableCell>
+                        <span className="text-xs text-muted-foreground">{player.club}</span>
+                      )
+                    ) : (
+                      /* Standard cell rendering */
+                      formatValue(getCellValue(player, col.key), col.format)
+                    )}
+                  </TableCell>
+                ))}
               </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell 
+                colSpan={columns.length} 
+                className="text-center text-muted-foreground py-8"
+              >
+                No hay resultados disponibles
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
     </div>
   );
 };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -34,7 +34,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
   ({ className, ...props }, ref) => (
     <tr
       ref={ref}
-      className={cn("border-b transition-colors data-[state=selected]:bg-muted hover:bg-muted/50", className)}
+      className={cn("border-b transition-colors data-[state=selected]:bg-muted", className)}
       {...props}
     />
   ),

--- a/src/hooks/useAllCompetenciasData.ts
+++ b/src/hooks/useAllCompetenciasData.ts
@@ -38,7 +38,17 @@ export const useAllCompetenciasWithPlayers = () => {
   // Step 1: Fetch master list to know all types
   const masterQuery = useQuery<CompetenciaTipo[]>({
     queryKey: ['competencias'],
-    queryFn: () => apiFetch<CompetenciaTipo[]>(getCompetenciasUrl()),
+    queryFn: async () => {
+      const data = await apiFetch<CompetenciaTipo[]>(getCompetenciasUrl());
+      // Transform API response to map 'descripcion' (backend) to 'description' (frontend)
+      return data.map(comp => ({
+        ...comp,
+        groups: comp.groups?.map(group => ({
+          ...group,
+          description: group.description || (group as unknown as Record<string, string>)['descripcion'] || group.name,
+        })) || [],
+      }));
+    },
     staleTime: POLL_ACTIVE,
   });
 
@@ -54,10 +64,18 @@ export const useAllCompetenciasWithPlayers = () => {
     queryFn: async () => {
       // Fetch detail for each unique base type in parallel
       const results = await Promise.all(
-        uniqueBaseTypes.map(tipo =>
-          apiFetch<CompetenciaTipo[]>(getCompetenciaDetailUrl(tipo))
-            .catch(() => [] as CompetenciaTipo[])
-        )
+        uniqueBaseTypes.map(async tipo => {
+          const data = await apiFetch<CompetenciaTipo[]>(getCompetenciaDetailUrl(tipo))
+            .catch(() => [] as CompetenciaTipo[]);
+          // Transform API response to map 'descripcion' (backend) to 'description' (frontend)
+          return data.map(comp => ({
+            ...comp,
+            groups: comp.groups?.map(group => ({
+              ...group,
+              description: group.description || (group as unknown as Record<string, string>)['descripcion'] || group.name,
+            })) || [],
+          }));
+        })
       );
       // Flatten all results into a single array
       return results.flat();

--- a/src/hooks/useAllCompetenciasData.ts
+++ b/src/hooks/useAllCompetenciasData.ts
@@ -1,0 +1,116 @@
+/**
+ * useAllCompetenciasData Hook
+ * Fetches ALL competition types with full player detail data
+ * Used by Premios page for cross-competition player search
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/apiClient';
+import { getCompetenciasUrl, getCompetenciaDetailUrl, POLL_ACTIVE } from '@/config/api';
+import type { CompetenciaTipo } from '@/data/competencias/types';
+
+// ============= Types =============
+
+/** Player result across a specific competition */
+export interface PlayerCompetitionResult {
+  /** Competition type info */
+  competenciaId: string;
+  competenciaName: string;
+  competenciaIcon: string;
+  /** Group info */
+  groupId: string;
+  groupName: string;
+  /** Player position in this group */
+  position: number;
+  /** Player name */
+  playerName: string;
+  /** All player fields for display */
+  playerData: Record<string, unknown>;
+}
+
+// ============= Hook =============
+
+/**
+ * Fetch the master list of competencias (without detail)
+ * then fetch detail for ALL types to enable cross-search
+ */
+export const useAllCompetenciasWithPlayers = () => {
+  // Step 1: Fetch master list to know all types
+  const masterQuery = useQuery<CompetenciaTipo[]>({
+    queryKey: ['competencias'],
+    queryFn: () => apiFetch<CompetenciaTipo[]>(getCompetenciasUrl()),
+    staleTime: POLL_ACTIVE,
+  });
+
+  // Step 2: Fetch all detail data (all types at once using tipo=all or iteratively)
+  // We'll fetch each type's detail and merge
+  const allTypes = masterQuery.data || [];
+  
+  // Extract unique base types from IDs (e.g., "oyes-1" → "oyes")
+  const uniqueBaseTypes = [...new Set(allTypes.map(c => c.id.split('-')[0]))];
+
+  const detailQuery = useQuery<CompetenciaTipo[]>({
+    queryKey: ['competencias', 'all-details', uniqueBaseTypes.join(',')],
+    queryFn: async () => {
+      // Fetch detail for each unique base type in parallel
+      const results = await Promise.all(
+        uniqueBaseTypes.map(tipo =>
+          apiFetch<CompetenciaTipo[]>(getCompetenciaDetailUrl(tipo))
+            .catch(() => [] as CompetenciaTipo[])
+        )
+      );
+      // Flatten all results into a single array
+      return results.flat();
+    },
+    enabled: uniqueBaseTypes.length > 0,
+    staleTime: POLL_ACTIVE,
+  });
+
+  return {
+    /** All competencias with player detail */
+    competencias: detailQuery.data || allTypes,
+    /** Loading state */
+    isLoading: masterQuery.isLoading || detailQuery.isLoading,
+  };
+};
+
+// ============= Search Helper =============
+
+/** Normalize text for accent-insensitive search */
+const normalizeText = (text: string): string =>
+  text.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+/**
+ * Search for a player across all competitions and groups
+ * Returns grouped results by competition type
+ */
+export const searchPlayerAcrossCompetencias = (
+  competencias: CompetenciaTipo[],
+  query: string
+): PlayerCompetitionResult[] => {
+  if (!query.trim()) return [];
+  
+  const normalizedQuery = normalizeText(query);
+  const results: PlayerCompetitionResult[] = [];
+
+  for (const comp of competencias) {
+    for (const group of comp.groups || []) {
+      for (const player of group.players || []) {
+        if (normalizeText(player.name).includes(normalizedQuery)) {
+          results.push({
+            competenciaId: comp.id,
+            competenciaName: comp.name,
+            competenciaIcon: comp.icon,
+            groupId: group.id,
+            groupName: group.name,
+            position: player.position,
+            playerName: player.name,
+            playerData: player as unknown as Record<string, unknown>,
+          });
+        }
+      }
+    }
+  }
+
+  return results;
+};

--- a/src/hooks/useCompetenciasData.ts
+++ b/src/hooks/useCompetenciasData.ts
@@ -40,11 +40,19 @@ export const useCompetencias = () => {
 export const useCompetenciaDetail = (tipo: string | null, enabled = true) => {
   return useQuery<CompetenciaTipo[]>({
     queryKey: ['competencias', tipo, 'detail'],
-    queryFn: () => apiFetch<CompetenciaTipo[]>(getCompetenciaDetailUrl(tipo!)),
+    queryFn: async () => {
+      const data = await apiFetch<CompetenciaTipo[]>(getCompetenciaDetailUrl(tipo!));
+      // Transform API response to map 'descripcion' (backend) to 'description' (frontend)
+      return data.map(comp => ({
+        ...comp,
+        groups: comp.groups?.map(group => ({
+          ...group,
+          description: group.description || (group as unknown as Record<string, string>)['descripcion'] || group.name,
+        })) || [],
+      }));
+    },
     enabled: enabled && !!tipo,
     staleTime: POLL_ACTIVE,
     refetchInterval: POLL_ACTIVE,
-    /** Extract the matching competition from the array */
-    select: (data) => data,
   });
 };

--- a/src/pages/Live.tsx
+++ b/src/pages/Live.tsx
@@ -397,7 +397,7 @@ const Live = () => {
                         <TableBody>
                           {leaderboard.players.map((player) => (
                             <Fragment key={player.playerId}>
-                              <TableRow className="bg-white hover:bg-muted/30">
+                              <TableRow className="bg-white">
                                 {/* Position */}
                                 <TableCell className="text-center font-bold">
                                   {player.position}

--- a/src/pages/Premios.tsx
+++ b/src/pages/Premios.tsx
@@ -1,75 +1,285 @@
+/**
+ * Premios Page
+ * Displays tournament prizes with a global player search
+ * Search finds a player across all competitions and shows
+ * grouped results by competition type with position/medal icons
+ */
+
+import { useState, useMemo } from 'react';
 import Layout from '@/components/layout/Layout';
 import PageHero from '@/components/shared/PageHero';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Trophy, Award, Medal, Star } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Trophy, Award, Medal, Star, Search, X, Target, Flag, Zap, Crosshair, Ruler, Loader2 } from 'lucide-react';
+import {
+  useAllCompetenciasWithPlayers,
+  searchPlayerAcrossCompetencias,
+  type PlayerCompetitionResult,
+} from '@/hooks/useAllCompetenciasData';
+
+// ============= Icon Mapping =============
+
+/** Map icon string names to Lucide icon components */
+const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+  target: Target,
+  trophy: Trophy,
+  flag: Flag,
+  zap: Zap,
+  star: Star,
+  award: Award,
+  medal: Medal,
+  crosshair: Crosshair,
+  ruler: Ruler,
+};
+
+/** Get icon component by name, fallback to Trophy */
+const getIcon = (iconName: string) => {
+  const IconComponent = iconMap[iconName] || Trophy;
+  return <IconComponent className="h-6 w-6" />;
+};
+
+// ============= Medal Helper =============
+
+/** Get medal emoji/icon for top positions */
+const getPositionDisplay = (position: number) => {
+  if (position === 1) return { emoji: '🥇', label: '1er Lugar', color: 'text-yellow-500' };
+  if (position === 2) return { emoji: '🥈', label: '2do Lugar', color: 'text-gray-400' };
+  if (position === 3) return { emoji: '🥉', label: '3er Lugar', color: 'text-amber-600' };
+  return { emoji: '', label: `${position}° Lugar`, color: 'text-foreground' };
+};
+
+// ============= Sub-Components =============
+
+/** Default prize cards shown when no search is active */
+const DefaultPrizeCards = () => (
+  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+    {/* Champion card */}
+    <Card className="border-border/50">
+      <CardHeader className="text-center pb-2">
+        <div className="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center mx-auto mb-4">
+          <Trophy className="h-8 w-8 text-amber-600" />
+        </div>
+        <CardTitle className="font-display">Campeón General</CardTitle>
+      </CardHeader>
+      <CardContent className="text-center text-muted-foreground">
+        <p>Trofeo conmemorativo y reconocimiento especial para el campeón absoluto del torneo.</p>
+      </CardContent>
+    </Card>
+
+    {/* Category card */}
+    <Card className="border-border/50">
+      <CardHeader className="text-center pb-2">
+        <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center mx-auto mb-4">
+          <Medal className="h-8 w-8 text-gray-600" />
+        </div>
+        <CardTitle className="font-display">Por Categoría</CardTitle>
+      </CardHeader>
+      <CardContent className="text-center text-muted-foreground">
+        <p>Premios para los tres primeros lugares de cada categoría del torneo.</p>
+      </CardContent>
+    </Card>
+
+    {/* Special prizes card */}
+    <Card className="border-border/50">
+      <CardHeader className="text-center pb-2">
+        <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4">
+          <Star className="h-8 w-8 text-primary" />
+        </div>
+        <CardTitle className="font-display">Premios Especiales</CardTitle>
+      </CardHeader>
+      <CardContent className="text-center text-muted-foreground">
+        <p>Hoyo en uno, drive más largo y tiro más cercano al hoyo.</p>
+      </CardContent>
+    </Card>
+
+    {/* Category prizes breakdown */}
+    <Card className="border-border/50 md:col-span-2 lg:col-span-3">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 font-display">
+          <Award className="h-5 w-5 text-accent" />
+          Premiación por Categoría
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {['1er Lugar', '2do Lugar', '3er Lugar', 'Mejor Neto'].map((premio, idx) => (
+            <div key={idx} className="text-center p-4 bg-muted rounded-lg">
+              <span className="text-2xl font-display font-bold text-accent block mb-1">
+                {idx === 0 ? '🥇' : idx === 1 ? '🥈' : idx === 2 ? '🥉' : '⭐'}
+              </span>
+              <span className="text-sm text-foreground font-medium">{premio}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+// ============= Search Results Component =============
+
+interface SearchResultsProps {
+  /** Grouped results by competition type */
+  groupedResults: Record<string, PlayerCompetitionResult[]>;
+  /** Player name searched */
+  playerName: string;
+}
+
+/** Display search results grouped by competition type */
+const SearchResults = ({ groupedResults, playerName }: SearchResultsProps) => {
+  const competitionIds = Object.keys(groupedResults);
+
+  if (competitionIds.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <Trophy className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+        <p className="text-muted-foreground">
+          No se encontraron resultados para "{playerName}"
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Results header */}
+      <div className="text-center mb-6">
+        <h2 className="text-2xl font-bold text-foreground">
+          Resultados de <span className="text-primary">{playerName}</span>
+        </h2>
+        <p className="text-muted-foreground mt-1">
+          Participó en {competitionIds.length} competencia{competitionIds.length !== 1 ? 's' : ''}
+        </p>
+      </div>
+
+      {/* Results by competition */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+        {competitionIds.map(compId => {
+          const results = groupedResults[compId];
+          const first = results[0];
+          return (
+            <Card key={compId} className="border-border/50 hover:shadow-md transition-shadow">
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-3 font-display text-lg">
+                  <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center text-primary">
+                    {getIcon(first.competenciaIcon)}
+                  </div>
+                  {first.competenciaName}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {results.map((result, idx) => {
+                  const pos = getPositionDisplay(result.position);
+                  return (
+                    <div
+                      key={`${result.groupId}-${idx}`}
+                      className="flex items-center justify-between p-3 bg-muted/50 rounded-lg"
+                    >
+                      <div>
+                        <p className="font-medium text-foreground">{result.groupName}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {pos.emoji && (
+                          <span className="text-xl">{pos.emoji}</span>
+                        )}
+                        <span className={`font-bold text-lg ${pos.color}`}>
+                          {pos.label}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// ============= Main Component =============
 
 const Premios = () => {
+  /** Search query state */
+  const [searchQuery, setSearchQuery] = useState('');
+
+  /** Fetch all competitions with player data */
+  const { competencias, isLoading } = useAllCompetenciasWithPlayers();
+
+  /** Search results grouped by competition ID */
+  const groupedResults = useMemo(() => {
+    const results = searchPlayerAcrossCompetencias(competencias, searchQuery);
+    // Group by competenciaId
+    return results.reduce<Record<string, PlayerCompetitionResult[]>>((acc, r) => {
+      if (!acc[r.competenciaId]) acc[r.competenciaId] = [];
+      acc[r.competenciaId].push(r);
+      return acc;
+    }, {});
+  }, [competencias, searchQuery]);
+
+  /** Derive player display name from first result */
+  const playerDisplayName = useMemo(() => {
+    const allResults = Object.values(groupedResults).flat();
+    return allResults.length > 0 ? allResults[0].playerName : searchQuery;
+  }, [groupedResults, searchQuery]);
+
+  /** Whether search is active */
+  const isSearchActive = searchQuery.trim().length > 0;
+
+  /** Clear search handler */
+  const handleClearSearch = () => setSearchQuery('');
+
   return (
     <Layout>
-      <PageHero 
+      <PageHero
         title="Premios"
         subtitle="Reconocimientos y premiación del torneo"
       />
+
       <section className="py-16 bg-background">
         <div className="container mx-auto px-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            <Card className="border-border/50">
-              <CardHeader className="text-center pb-2">
-                <div className="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center mx-auto mb-4">
-                  <Trophy className="h-8 w-8 text-amber-600" />
-                </div>
-                <CardTitle className="font-display">Campeón General</CardTitle>
-              </CardHeader>
-              <CardContent className="text-center text-muted-foreground">
-                <p>Trofeo conmemorativo y reconocimiento especial para el campeón absoluto del torneo.</p>
-              </CardContent>
-            </Card>
 
-            <Card className="border-border/50">
-              <CardHeader className="text-center pb-2">
-                <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center mx-auto mb-4">
-                  <Medal className="h-8 w-8 text-gray-600" />
-                </div>
-                <CardTitle className="font-display">Por Categoría</CardTitle>
-              </CardHeader>
-              <CardContent className="text-center text-muted-foreground">
-                <p>Premios para los tres primeros lugares de cada categoría del torneo.</p>
-              </CardContent>
-            </Card>
-
-            <Card className="border-border/50">
-              <CardHeader className="text-center pb-2">
-                <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4">
-                  <Star className="h-8 w-8 text-primary" />
-                </div>
-                <CardTitle className="font-display">Premios Especiales</CardTitle>
-              </CardHeader>
-              <CardContent className="text-center text-muted-foreground">
-                <p>Hoyo en uno, drive más largo y tiro más cercano al hoyo.</p>
-              </CardContent>
-            </Card>
-
-            <Card className="border-border/50 md:col-span-2 lg:col-span-3">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 font-display">
-                  <Award className="h-5 w-5 text-accent" />
-                  Premiación por Categoría
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  {['1er Lugar', '2do Lugar', '3er Lugar', 'Mejor Neto'].map((premio, idx) => (
-                    <div key={idx} className="text-center p-4 bg-muted rounded-lg">
-                      <span className="text-2xl font-display font-bold text-accent block mb-1">
-                        {idx === 0 ? '🥇' : idx === 1 ? '🥈' : idx === 2 ? '🥉' : '⭐'}
-                      </span>
-                      <span className="text-sm text-foreground font-medium">{premio}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
+          {/* Player Search Bar */}
+          <div className="max-w-md mx-auto mb-10">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                type="text"
+                placeholder="Buscar jugador por nombre..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10 pr-10"
+              />
+              {searchQuery && (
+                <button
+                  onClick={handleClearSearch}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label="Limpiar búsqueda"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
           </div>
+
+          {/* Loading state */}
+          {isLoading && isSearchActive && (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <span className="ml-3 text-muted-foreground">Cargando competencias...</span>
+            </div>
+          )}
+
+          {/* Search results or default cards */}
+          {isSearchActive ? (
+            <SearchResults
+              groupedResults={groupedResults}
+              playerName={playerDisplayName}
+            />
+          ) : (
+            <DefaultPrizeCards />
+          )}
         </div>
       </section>
     </Layout>

--- a/src/pages/Resultados.tsx
+++ b/src/pages/Resultados.tsx
@@ -425,7 +425,7 @@ const Resultados = () => {
 
                               {/* Non-NORMAL players (S/R/D) */}
                               {cutPlayers.map((cp) => (
-                                <TableRow key={cp.playerId} className="bg-muted/20 hover:bg-muted/30">
+                                <TableRow key={cp.playerId} className="bg-muted/20">
                                   {/* Status code instead of position */}
                                   <TableCell className="font-semibold text-center">
                                     <span className={`inline-block px-2 py-0.5 rounded text-xs font-bold ${getStatusBadgeClasses(cp.statusCode)}`}>


### PR DESCRIPTION
## What
Improves visibility for competicion's prizes, search and hovers for all player tables, enabling a better feel for each player looking up their results, understanding each competition and corresponding prizes, and doing global searches for themselves.

## Why
Feature fixes searching capabilities and menu/deep-dives per competition type which proved tiresome/burdensome. apparently old people dont like hovers and not losing themselves to whatever theyre selecting. lastly, proper descriptions per prize are in order.

## Changes
- Fix mapping between premiations and descriptions
- Validates full premiation configuration 
- Display prize descriptions in reports
- Eliminates cream-colored hover on players
- Changes specific search per competition to global for all competitions

## Related Issues
Closes #19 
Closes #9 
Closes #10 


## How to test
- use competicion searchbar and it filters accordingly
- hover over players, no color change in any table jugadores/resultados/competicion/o'yes/putt/driver/approach/etc
- prize descriptions are valid not "premio x" but related to the description in BD for all competiciones

## Notes (optional)
-
- known limitations include feasibility for global search and page structure after search. Needs new issue to improve.