### PR TITLE
Feature/ux UI 23 24 25

### DIFF
--- a/src/components/competencias/CompetenciasTable.tsx
+++ b/src/components/competencias/CompetenciasTable.tsx
@@ -60,7 +60,7 @@ const getCellValue = (player: CompetenciaPlayer, key: string): unknown => {
 const CompetenciasTable = ({ players, columns }: CompetenciasTableProps) => {
   return (
     <div className="overflow-x-auto bg-white rounded-lg">
-      <Table>
+      <Table className="tournament-table">
         {/* Table Header */}
         <TableHeader>
           <TableRow className="bg-primary hover:bg-primary">
@@ -92,6 +92,7 @@ const CompetenciasTable = ({ players, columns }: CompetenciasTableProps) => {
                     key={col.key}
                     className={`${
                       col.key === 'clubLogo' ? 'p-1 text-center align-middle' :
+                      col.key === 'name' ? 'player-name-cell' :
                       col.align === 'center' ? 'text-center' : 
                       col.align === 'right' ? 'text-right' : 'text-left'
                     }`}

--- a/src/components/resultados/ScorecardRow.tsx
+++ b/src/components/resultados/ScorecardRow.tsx
@@ -193,6 +193,7 @@ const ScorecardRow = ({ scorecard, playerName, roundLabel, onClose, colSpan }: S
         <div className="p-4 border-t border-b border-primary/20">
           {/* Header */}
           <div className="flex items-center justify-between mb-3">
+            {/* Left section: player name, round, type */}
             <div className="flex items-center gap-2 flex-wrap">
               <span className="font-bold text-foreground">{playerName}</span>
               <span className="px-2 py-0.5 rounded-full bg-primary text-primary-foreground text-xs font-semibold">
@@ -202,16 +203,20 @@ const ScorecardRow = ({ scorecard, playerName, roundLabel, onClose, colSpan }: S
               <span className="px-2 py-0.5 rounded-full bg-muted text-muted-foreground text-xs">
                 {scorecardTypeLabels[type]}
               </span>
-              {/* Date badge - formatted from YYYY-MM-DD */}
+            </div>
+
+            {/* Right section: date (aligned right) and close button */}
+            <div className="flex items-center gap-3">
+              {/* Date badge - aligned to the right */}
               {scorecard.date && scorecard.date !== '0' && (
-                <span className="text-muted-foreground text-xs">
+                <span className="text-muted-foreground text-xs text-right">
                   Fecha: {scorecard.date}
                 </span>
               )}
+              <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
+                <X className="h-4 w-4" />
+              </button>
             </div>
-            <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
-              <X className="h-4 w-4" />
-            </button>
           </div>
 
           {/* Scorecard grid */}

--- a/src/index.css
+++ b/src/index.css
@@ -242,18 +242,20 @@
   display: none;
 }
 
-/* ============= Tournament Table Scaling & Name Wrapping ============= */
+/* ============= Tournament Table Scaling & Name Wrapping (mobile only) ============= */
 
-/** Scale tournament tables to 85% for better viewport fit */
-.tournament-table {
-  zoom: 0.85;
-}
+@media (max-width: 767px) {
+  /** Scale tournament tables to 85% on mobile for better viewport fit */
+  .tournament-table {
+    zoom: 0.85;
+  }
 
-/** Player name cells: wrap text tightly with no extra line spacing */
-.player-name-cell {
-  max-width: 160px;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  line-height: 1.15;
-  white-space: normal;
+  /** Player name cells: wrap text tightly with no extra line spacing */
+  .player-name-cell {
+    max-width: 160px;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    line-height: 1.15;
+    white-space: normal;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -241,3 +241,19 @@
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
+/* ============= Tournament Table Scaling & Name Wrapping ============= */
+
+/** Scale tournament tables to 85% for better viewport fit */
+.tournament-table {
+  zoom: 0.85;
+}
+
+/** Player name cells: wrap text tightly with no extra line spacing */
+.player-name-cell {
+  max-width: 160px;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  line-height: 1.15;
+  white-space: normal;
+}

--- a/src/pages/Jugadores.tsx
+++ b/src/pages/Jugadores.tsx
@@ -134,7 +134,7 @@ const Jugadores = () => {
                       <Loader2 className="h-8 w-8 animate-spin text-primary" />
                     </div>
                   ) : (
-                    <Table className="bg-white">
+                    <Table className="bg-white tournament-table">
                       <TableHeader>
                         <TableRow className="bg-primary hover:bg-primary">
                           <TableHead className="text-primary-foreground font-bold text-center">Club</TableHead>
@@ -203,7 +203,7 @@ const Jugadores = () => {
                                    }}
                                  />
                                </TableCell>
-                               <TableCell>{player.name}</TableCell>
+                               <TableCell className="player-name-cell">{player.name}</TableCell>
                               <TableCell className="text-right">{player.handicapIndex.toFixed(1)}</TableCell>
                               <TableCell className="text-right">{player.handicapJuego}</TableCell>
                               <TableCell className="text-right">{player.handicapNeto}</TableCell>

--- a/src/pages/Live.tsx
+++ b/src/pages/Live.tsx
@@ -381,7 +381,7 @@ const Live = () => {
                 <Card className="border-border/50 max-w-5xl mx-auto overflow-hidden">
                   <CardContent className="p-0">
                     <div className="overflow-x-auto">
-                      <Table>
+                      <Table className="tournament-table">
                         <TableHeader>
                           <TableRow className="bg-primary hover:bg-primary">
                             <TableHead className="text-primary-foreground font-bold w-[50px] text-center">Pos</TableHead>
@@ -416,7 +416,7 @@ const Live = () => {
                                 </TableCell>
 
                                 {/* Player name */}
-                                <TableCell className="font-medium">
+                                <TableCell className="font-medium player-name-cell">
                                   {player.name}
                                 </TableCell>
 

--- a/src/pages/Resultados.tsx
+++ b/src/pages/Resultados.tsx
@@ -311,7 +311,7 @@ const Resultados = () => {
                 <Card className="border-border/50 bg-white max-w-5xl mx-auto">
                   <CardContent className="p-0 bg-white">
                     <div className="overflow-x-auto bg-white">
-                      <Table className="bg-white">
+                      <Table className="bg-white tournament-table">
                         <TableHeader>
                           <TableRow className="bg-primary hover:bg-primary">
                             <TableHead className="text-primary-foreground font-bold w-16">Pos</TableHead>
@@ -354,7 +354,7 @@ const Resultados = () => {
                                       <span className="text-xs text-muted-foreground">{player.club}</span>
                                     )}
                                   </TableCell>
-                                  <TableCell className="font-medium">{player.name}</TableCell>
+                                  <TableCell className="font-medium player-name-cell">{player.name}</TableCell>
                                   {/* Dynamic round score cells */}
                                   {(categoryDetail?.days || []).map((_, i) => {
                                     const round = i + 1;
@@ -449,7 +449,7 @@ const Resultados = () => {
                                     )}
                                   </TableCell>
                                   {/* Player name + status label */}
-                                  <TableCell className="font-medium text-muted-foreground">
+                                  <TableCell className="font-medium text-muted-foreground player-name-cell">
                                     {cp.name}
                                     <span className="ml-2 text-xs text-muted-foreground/70">({cp.statusLabel})</span>
                                   </TableCell>

--- a/src/pages/Salidas.tsx
+++ b/src/pages/Salidas.tsx
@@ -419,7 +419,15 @@ const Salidas = () => {
                     <CardContent className="p-5 text-center">
                       <Users className="h-6 w-6 mx-auto mb-2 text-primary" />
                       <h3 className="font-bold text-foreground text-lg mb-1">{cat.shortName || cat.categoryName}</h3>
-                      <p className="text-xs text-muted-foreground">{cat.tee}</p>
+                      <p className="text-xs text-muted-foreground mb-2">{cat.tee}</p>
+                      {/* Group count badge */}
+                      {groupCountMap[String(cat.caljgoid)] !== undefined ? (
+                        <p className="text-sm text-muted-foreground">
+                          <span className="text-lg font-bold text-primary">{groupCountMap[String(cat.caljgoid)]}</span> grupo{groupCountMap[String(cat.caljgoid)] !== 1 ? 's' : ''}
+                        </p>
+                      ) : (
+                        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground mx-auto" />
+                      )}
                     </CardContent>
                   </Card>
                 ))}

--- a/src/pages/Salidas.tsx
+++ b/src/pages/Salidas.tsx
@@ -265,7 +265,7 @@ const Salidas = () => {
                             </div>
                             {/* Group table */}
                             <div className="overflow-x-auto bg-white">
-                              <Table className="bg-white">
+                              <Table className="bg-white tournament-table">
                                 <TableHeader>
                                   <TableRow className="bg-primary hover:bg-primary">
                                     <TableHead className="text-primary-foreground font-bold text-center w-20">Hoyo</TableHead>
@@ -306,7 +306,7 @@ const Salidas = () => {
                                           <span className="text-xs text-muted-foreground">—</span>
                                         )}
                                       </TableCell>
-                                      <TableCell className={`font-medium ${pIdx === result.matchedPlayerIdx ? 'text-primary font-bold' : 'text-foreground'}`}>
+                                      <TableCell className={`font-medium player-name-cell ${pIdx === result.matchedPlayerIdx ? 'text-primary font-bold' : 'text-foreground'}`}>
                                         {player.name}
                                       </TableCell>
                                       <TableCell className="text-center font-bold text-primary">
@@ -436,7 +436,7 @@ const Salidas = () => {
                     <Card className="border-border/50 bg-white max-w-5xl mx-auto">
                       <CardContent className="p-0 bg-white">
                         <div className="overflow-x-auto bg-white">
-                          <Table className="bg-white">
+                          <Table className="bg-white tournament-table">
                             <TableHeader>
                               <TableRow className="bg-primary hover:bg-primary">
                                 <TableHead className="text-primary-foreground font-bold text-center w-20">Hoyo</TableHead>
@@ -488,7 +488,7 @@ const Salidas = () => {
                                         <span className="text-xs text-muted-foreground">—</span>
                                       )}
                                     </TableCell>
-                                    <TableCell className="font-medium text-foreground">
+                                    <TableCell className="font-medium text-foreground player-name-cell">
                                       {player.name}
                                     </TableCell>
                                     <TableCell className="text-center font-bold text-primary">

--- a/src/pages/Salidas.tsx
+++ b/src/pages/Salidas.tsx
@@ -142,6 +142,31 @@ const Salidas = () => {
     error: detailError,
   } = useSalidasDetail(selectedCaljgoid, selectedFormato);
 
+  /** Fetch group counts for all categories of the selected day (for card badges) */
+  const categoryGroupQueries = useQueries({
+    queries: selectedDay && !selectedCaljgoid
+      ? selectedDay.categories.map((cat) => ({
+          queryKey: ['salidas-group-count', String(cat.caljgoid), cat.format?.toLowerCase().includes('pareja') ? 'parejas' : 'individual'],
+          queryFn: async () => {
+            const fmt = cat.format?.toLowerCase().includes('pareja') ? 'parejas' : 'individual';
+            const data = await apiFetch<any>(getSalidasDayUrl(String(cat.caljgoid), fmt));
+            const groups = Array.isArray(data?.groups) ? data.groups : [];
+            return { caljgoid: String(cat.caljgoid), groupCount: groups.length };
+          },
+          staleTime: POLL_ACTIVE,
+        }))
+      : [],
+  });
+
+  /** Map caljgoid → group count for quick lookup */
+  const groupCountMap = useMemo<Record<string, number>>(() => {
+    const map: Record<string, number> = {};
+    for (const q of categoryGroupQueries) {
+      if (q.data) map[q.data.caljgoid] = q.data.groupCount;
+    }
+    return map;
+  }, [categoryGroupQueries]);
+
   /** Handle day card click - if only one category, go directly to detail */
   const handleDayClick = (dayIdx: number) => {
     const day = days[dayIdx];

--- a/src/pages/Salidas.tsx
+++ b/src/pages/Salidas.tsx
@@ -142,6 +142,9 @@ const Salidas = () => {
     error: detailError,
   } = useSalidasDetail(selectedCaljgoid, selectedFormato);
 
+  /** Currently selected day object */
+  const selectedDay: SalidasDay | null = selectedDayIdx !== null ? days[selectedDayIdx] : null;
+
   /** Fetch group counts for all categories of the selected day (for card badges) */
   const categoryGroupQueries = useQueries({
     queries: selectedDay && !selectedCaljgoid

--- a/src/pages/Salidas.tsx
+++ b/src/pages/Salidas.tsx
@@ -213,9 +213,6 @@ const Salidas = () => {
     setSearchActive(false);
   };
 
-  /** Currently selected day object */
-  const selectedDay: SalidasDay | null = selectedDayIdx !== null ? days[selectedDayIdx] : null;
-
   return (
     <Layout>
       <PageHero

--- a/src/pages/Salidas.tsx
+++ b/src/pages/Salidas.tsx
@@ -1,7 +1,7 @@
 /**
  * Salidas Page
  * Displays tee times organized by day → category → groups
- * Uses table format consistent with other pages (Resultados, etc.)
+ * Includes player search across all days/categories
  * Data fetched from salidas.php and salidas_det.php via React Query hooks
  */
 
@@ -9,14 +9,37 @@ import Layout from '@/components/layout/Layout';
 import PageHero from '@/components/shared/PageHero';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { ArrowLeft, Calendar, Loader2, Users } from 'lucide-react';
-import { useState } from 'react';
+import { ArrowLeft, Calendar, Loader2, Search, Users, X } from 'lucide-react';
+import { useState, useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
 import { useSalidasMaster, useSalidasDetail } from '@/hooks/useSalidasData';
-import type { SalidasDay, SalidasCategory } from '@/hooks/useSalidasData';
-import { LOGOS_BASE_URL } from '@/config/api';
+import type { SalidasDay, SalidasCategory, SalidasDetailResponse, SalidasGroup } from '@/hooks/useSalidasData';
+import { apiFetch } from '@/lib/apiClient';
+import { getSalidasDayUrl, POLL_ACTIVE } from '@/config/api';
 import { ApiError } from '@/lib/apiClient';
 import salidasHero from '@/assets/salidas-hero.jpg';
+
+// ============= Search Result Type =============
+
+/** Represents a player search match with full group context */
+interface SearchResult {
+  /** Day display label */
+  dayLabel: string;
+  /** Course name */
+  course: string;
+  /** Category name */
+  categoryName: string;
+  /** Scoring system (e.g. Medal Play, Stableford) */
+  system: string;
+  /** Tee assignment */
+  tee: string;
+  /** The full group containing the matched player */
+  group: SalidasGroup;
+  /** Index of matched player within the group */
+  matchedPlayerIdx: number;
+}
 
 // ============= Component =============
 
@@ -27,10 +50,86 @@ const Salidas = () => {
   const [selectedCaljgoid, setSelectedCaljgoid] = useState<string | null>(null);
   /** Selected category metadata for header display */
   const [selectedCatMeta, setSelectedCatMeta] = useState<SalidasCategory | null>(null);
+  /** Player search query */
+  const [searchQuery, setSearchQuery] = useState('');
+  /** Whether search mode is active */
+  const [searchActive, setSearchActive] = useState(false);
 
   // Fetch master data: days + categories
   const { data: master, isLoading: loadingMaster } = useSalidasMaster();
   const days = master?.days ?? [];
+
+  /** Collect all caljgoids across all days for search queries */
+  const allCategories = useMemo(() => {
+    return days.flatMap((day) =>
+      day.categories.map((cat) => ({
+        caljgoid: String(cat.caljgoid),
+        formato: cat.format?.toLowerCase().includes('pareja') ? 'parejas' : 'individual',
+        dayLabel: day.dateFormatted,
+        course: day.course,
+      }))
+    );
+  }, [days]);
+
+  /** Fetch all category details in parallel for search (only when search is active) */
+  const searchQueries = useQueries({
+    queries: searchActive && searchQuery.trim().length >= 2
+      ? allCategories.map((cat) => ({
+          queryKey: ['salidas-detail', cat.caljgoid, cat.formato],
+          queryFn: async () => {
+            const data = await apiFetch<any>(getSalidasDayUrl(cat.caljgoid, cat.formato));
+            return {
+              ...cat,
+              detail: {
+                caljgoid: data?.caljgoid ?? cat.caljgoid,
+                date: data?.date ?? '',
+                course: data?.course ?? cat.course,
+                categoryId: data?.categoryId ?? '',
+                categoryName: data?.categoryName ?? '',
+                shortName: data?.shortName ?? '',
+                system: data?.system ?? '',
+                tee: data?.tee ?? '',
+                groups: Array.isArray(data?.groups) ? data.groups : [],
+              } as SalidasDetailResponse,
+            };
+          },
+          staleTime: POLL_ACTIVE,
+          enabled: searchActive && searchQuery.trim().length >= 2,
+        }))
+      : [],
+  });
+
+  /** Filter search results based on query */
+  const searchResults = useMemo<SearchResult[]>(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (q.length < 2) return [];
+
+    const results: SearchResult[] = [];
+    for (const query of searchQueries) {
+      if (!query.data?.detail) continue;
+      const { dayLabel, course, detail } = query.data;
+      for (const group of detail.groups) {
+        const matchIdx = group.players.findIndex((p) =>
+          p.name.toLowerCase().includes(q)
+        );
+        if (matchIdx !== -1) {
+          results.push({
+            dayLabel,
+            course,
+            categoryName: detail.categoryName,
+            system: detail.system,
+            tee: detail.tee,
+            group,
+            matchedPlayerIdx: matchIdx,
+          });
+        }
+      }
+    }
+    return results;
+  }, [searchQuery, searchQueries]);
+
+  /** Whether search data is still loading */
+  const searchLoading = searchActive && searchQuery.trim().length >= 2 && searchQueries.some((q) => q.isLoading);
 
   /** Normalize selected format to endpoint-compatible values */
   const selectedFormato = selectedCatMeta?.format?.toLowerCase().includes('pareja') ? 'parejas' : 'individual';
@@ -47,7 +146,6 @@ const Salidas = () => {
   const handleDayClick = (dayIdx: number) => {
     const day = days[dayIdx];
     if (day.categories.length === 1) {
-      // Skip category selection, go directly to groups
       setSelectedDayIdx(dayIdx);
       setSelectedCaljgoid(String(day.categories[0].caljgoid));
       setSelectedCatMeta(day.categories[0]);
@@ -67,28 +165,28 @@ const Salidas = () => {
   /** Handle back navigation */
   const handleBack = () => {
     if (selectedCaljgoid) {
-      // If day has multiple categories, go back to category selection
       const day = selectedDayIdx !== null ? days[selectedDayIdx] : null;
       if (day && day.categories.length > 1) {
         setSelectedCaljgoid(null);
         setSelectedCatMeta(null);
       } else {
-        // Single category day - go back to days
         setSelectedDayIdx(null);
         setSelectedCaljgoid(null);
         setSelectedCatMeta(null);
       }
     } else {
-      // Back to days
       setSelectedDayIdx(null);
     }
   };
 
+  /** Clear search and return to normal view */
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setSearchActive(false);
+  };
+
   /** Currently selected day object */
   const selectedDay: SalidasDay | null = selectedDayIdx !== null ? days[selectedDayIdx] : null;
-
-  /** Total groups across all days for header */
-  const totalCategories = days.reduce((sum, d) => sum + d.categories.length, 0);
 
   return (
     <Layout>
@@ -109,37 +207,166 @@ const Salidas = () => {
                 </h2>
               </div>
 
-              {loadingMaster ? (
-                <div className="flex justify-center py-12">
-                  <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              {/* ============= Player Search Bar ============= */}
+              {!loadingMaster && days.length > 0 && (
+                <div className="max-w-md mx-auto mb-8">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    <Input
+                      type="text"
+                      placeholder="Buscar jugador por nombre..."
+                      value={searchQuery}
+                      onChange={(e) => {
+                        setSearchQuery(e.target.value);
+                        if (e.target.value.trim().length >= 2) {
+                          setSearchActive(true);
+                        }
+                      }}
+                      className="pl-10 pr-10"
+                    />
+                    {searchQuery && (
+                      <button
+                        onClick={handleClearSearch}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    )}
+                  </div>
                 </div>
-              ) : days.length === 0 ? (
-                <div className="text-center py-16">
-                  <Calendar className="h-12 w-12 mx-auto mb-4 text-muted-foreground/50" />
-                  <p className="text-muted-foreground text-lg">No hay salidas disponibles</p>
+              )}
+
+              {/* ============= Search Results ============= */}
+              {searchActive && searchQuery.trim().length >= 2 ? (
+                <div className="max-w-5xl mx-auto">
+                  {searchLoading ? (
+                    <div className="flex justify-center py-12">
+                      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                    </div>
+                  ) : searchResults.length === 0 ? (
+                    <div className="text-center py-12">
+                      <Search className="h-10 w-10 mx-auto mb-3 text-muted-foreground/50" />
+                      <p className="text-muted-foreground">No se encontró ningún jugador con "{searchQuery}"</p>
+                    </div>
+                  ) : (
+                    <div className="space-y-6">
+                      <p className="text-sm text-muted-foreground text-center mb-4">
+                        {searchResults.length} grupo{searchResults.length !== 1 ? 's' : ''} encontrado{searchResults.length !== 1 ? 's' : ''}
+                      </p>
+                      {searchResults.map((result, rIdx) => (
+                        <Card key={rIdx} className="border-border/50 bg-white">
+                          <CardContent className="p-0 bg-white">
+                            {/* Result context header */}
+                            <div className="bg-muted/50 px-4 py-2 border-b border-border/30 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+                              <span className="font-semibold text-foreground capitalize">{result.dayLabel}</span>
+                              <span className="text-muted-foreground">{result.course}</span>
+                              <span className="text-primary font-medium">{result.categoryName}</span>
+                              <span className="text-muted-foreground">{result.system} · Tee: {result.tee}</span>
+                            </div>
+                            {/* Group table */}
+                            <div className="overflow-x-auto bg-white">
+                              <Table className="bg-white">
+                                <TableHeader>
+                                  <TableRow className="bg-primary hover:bg-primary">
+                                    <TableHead className="text-primary-foreground font-bold text-center w-20">Hoyo</TableHead>
+                                    <TableHead className="text-primary-foreground font-bold text-center w-20">Hora</TableHead>
+                                    <TableHead className="text-primary-foreground font-bold text-center w-16">Club</TableHead>
+                                    <TableHead className="text-primary-foreground font-bold">Jugador</TableHead>
+                                    <TableHead className="text-primary-foreground font-bold text-center w-20">Score</TableHead>
+                                  </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                  {result.group.players.map((player, pIdx) => (
+                                    <TableRow
+                                      key={pIdx}
+                                      className={`bg-white hover:bg-white ${
+                                        pIdx === result.matchedPlayerIdx ? 'bg-primary/5 hover:bg-primary/5' : ''
+                                      }`}
+                                    >
+                                      {pIdx === 0 ? (
+                                        <>
+                                          <TableCell className="text-center font-bold text-foreground" rowSpan={result.group.players.length}>
+                                            {result.group.tee}
+                                          </TableCell>
+                                          <TableCell className="text-center font-medium text-foreground" rowSpan={result.group.players.length}>
+                                            {result.group.time}
+                                          </TableCell>
+                                        </>
+                                      ) : null}
+                                      <TableCell className="p-1 text-center align-middle">
+                                        {player.clubLogo ? (
+                                          <img
+                                            src={player.clubLogo}
+                                            alt="Club"
+                                            className="w-auto object-contain rounded inline-block"
+                                            style={{ height: '2.25rem' }}
+                                            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                                          />
+                                        ) : (
+                                          <span className="text-xs text-muted-foreground">—</span>
+                                        )}
+                                      </TableCell>
+                                      <TableCell className={`font-medium ${pIdx === result.matchedPlayerIdx ? 'text-primary font-bold' : 'text-foreground'}`}>
+                                        {player.name}
+                                      </TableCell>
+                                      <TableCell className="text-center font-bold text-primary">
+                                        {player.score || '—'}
+                                      </TableCell>
+                                    </TableRow>
+                                  ))}
+                                </TableBody>
+                                {/* Footer with category name */}
+                                <tfoot>
+                                  <tr className="bg-primary">
+                                    <td colSpan={5} className="text-primary-foreground font-bold text-center py-2 text-sm">
+                                      {result.categoryName}
+                                    </td>
+                                  </tr>
+                                </tfoot>
+                              </Table>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      ))}
+                    </div>
+                  )}
                 </div>
               ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
-                  {days.map((day, idx) => (
-                    <Card
-                      key={idx}
-                      className="border-border/50 hover:border-primary/50 transition-all hover:shadow-lg cursor-pointer"
-                      onClick={() => handleDayClick(idx)}
-                    >
-                      <CardContent className="p-6 text-center">
-                        <Calendar className="h-8 w-8 mx-auto mb-3 text-primary" />
-                        <h3 className="font-bold text-foreground text-lg mb-1 capitalize">{day.dateFormatted}</h3>
-                        <p className="text-muted-foreground text-sm mb-3">{day.course}</p>
-                        <div className="flex justify-center gap-4 text-sm">
-                          <div>
-                            <span className="text-2xl font-bold text-primary">{day.categories.length}</span>
-                            <p className="text-muted-foreground">Categorías</p>
-                          </div>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
+                /* ============= Day Cards Grid ============= */
+                <>
+                  {loadingMaster ? (
+                    <div className="flex justify-center py-12">
+                      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                    </div>
+                  ) : days.length === 0 ? (
+                    <div className="text-center py-16">
+                      <Calendar className="h-12 w-12 mx-auto mb-4 text-muted-foreground/50" />
+                      <p className="text-muted-foreground text-lg">No hay salidas disponibles</p>
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
+                      {days.map((day, idx) => (
+                        <Card
+                          key={idx}
+                          className="border-border/50 hover:border-primary/50 transition-all hover:shadow-lg cursor-pointer"
+                          onClick={() => handleDayClick(idx)}
+                        >
+                          <CardContent className="p-6 text-center">
+                            <Calendar className="h-8 w-8 mx-auto mb-3 text-primary" />
+                            <h3 className="font-bold text-foreground text-lg mb-1 capitalize">{day.dateFormatted}</h3>
+                            <p className="text-muted-foreground text-sm mb-3">{day.course}</p>
+                            <div className="flex justify-center gap-4 text-sm">
+                              <div>
+                                <span className="text-2xl font-bold text-primary">{day.categories.length}</span>
+                                <p className="text-muted-foreground">Categorías</p>
+                              </div>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      ))}
+                    </div>
+                  )}
+                </>
               )}
             </>
 
@@ -230,7 +457,6 @@ const Salidas = () => {
                                         : ''
                                     }`}
                                   >
-                                    {/* Show hole and time only on first player of each group */}
                                     {pIdx === 0 ? (
                                       <>
                                         <TableCell
@@ -247,7 +473,6 @@ const Salidas = () => {
                                         </TableCell>
                                       </>
                                     ) : null}
-                                    {/* Club logo */}
                                     <TableCell className="p-1 text-center align-middle">
                                       {player.clubLogo ? (
                                         <img
@@ -263,11 +488,9 @@ const Salidas = () => {
                                         <span className="text-xs text-muted-foreground">—</span>
                                       )}
                                     </TableCell>
-                                    {/* Player name */}
                                     <TableCell className="font-medium text-foreground">
                                       {player.name}
                                     </TableCell>
-                                    {/* Score */}
                                     <TableCell className="text-center font-bold text-primary">
                                       {player.score || '—'}
                                     </TableCell>


### PR DESCRIPTION
## What
UX/UI improvements for mobile, salidas, and hovering in tables 

## Why
Hovering in tables changed colors to the player that made their club logo loook ugly as they're not webp or png so it was deemed unsuitable. Mobile tables needed smaller viewports and namewrapping to fit tables in a single screen.
Salidas needed information per group to estimate times and marshal pushes.

## Changes
- clean hovers
- mobile viewport reduces and wraps to fit in a single screen
- salidas has group count per category


## Related Issues
Closes #6 
Closes #23 
Closes #24  
Closes #25 

## How to test
- displays group count in salidas per category and loader icon
- no hover in any jugadores, resultados, or competicion table
- mobile displays a fuller table without scrolling

## Notes
- maintained search bars across other pages.