### PR TITLE
Feat/sponsor ribbon amount order 63

### DIFF
--- a/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
+++ b/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
@@ -2,20 +2,161 @@
  * AdminSponsorsCarousel Component
  * Sub-tab inside Admin → Patrocinadores.
  *
- * Placeholder for the upcoming "Carrusel" feature (large rotating sponsor
- * showcase). The configuration UI for this feature will be added in the
- * next iteration.
+ * Lets the admin configure how the public sponsor ribbon/carousel is displayed:
+ *  - Drag-and-drop ordering of sponsor logos (uses @hello-pangea/dnd).
+ *  - Randomize toggle: when on, the ribbon is shuffled on every page load
+ *    and the manual order is ignored on the public site (kept here as a fallback).
+ *  - Visible count: caps how many distinct sponsor logos appear in the ribbon
+ *    at any given time (0 = show all).
+ *
+ * Persisted server-side via `sponsors_config.carousel` in the site_config row.
  */
 
+import { useEffect, useMemo, useState } from 'react';
+import { DragDropContext, Droppable, Draggable, type DropResult } from '@hello-pangea/dnd';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { GalleryHorizontal, Wrench } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import {
+  GalleryHorizontal,
+  GripVertical,
+  Loader2,
+  Save,
+  Shuffle,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useSiteConfig, useSaveSiteConfig } from '@/hooks/useSiteConfig';
+import { useToast } from '@/hooks/use-toast';
+import { useSponsors } from '@/hooks/useTournamentData';
+import SponsorLogoImage from '@/components/sponsors/SponsorLogoImage';
+
+// ============= Constants =============
+
+/** Default visibleCount used when nothing is stored yet (0 = "all") */
+const DEFAULT_VISIBLE_COUNT = 0;
+
+// ============= Helpers =============
+
+/**
+ * Reorder helper used by the drag-and-drop callback to move an item from one
+ * index to another while preserving the rest of the list.
+ */
+const reorder = <T,>(list: T[], startIndex: number, endIndex: number): T[] => {
+  const result = [...list];
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+  return result;
+};
+
+// ============= Component =============
 
 /**
  * AdminSponsorsCarousel
- * Currently displays an "in progress" placeholder so the tab structure
- * is in place ahead of the carousel feature implementation.
+ * Drag-and-drop ordering + randomize toggle + visible-count selector for the
+ * public sponsor ribbon. Saves to `site_config.sponsors_config.carousel`.
  */
 const AdminSponsorsCarousel = () => {
+  const { data: siteConfig, isLoading: isLoadingConfig } = useSiteConfig();
+  const { data: sponsors = [], isLoading: isLoadingSponsors } = useSponsors();
+  const saveSiteConfig = useSaveSiteConfig();
+  const { toast } = useToast();
+
+  /** Saved carousel config (or sane defaults) */
+  const savedCarousel = siteConfig?.sponsors_config?.carousel ?? {};
+
+  /** Local draft state — order of sponsor IDs */
+  const [orderedIds, setOrderedIds] = useState<number[]>([]);
+  /** Local draft state — randomize on each page load */
+  const [randomize, setRandomize] = useState<boolean>(false);
+  /** Local draft state — max distinct logos visible at any time (0 = all) */
+  const [visibleCount, setVisibleCount] = useState<number>(DEFAULT_VISIBLE_COUNT);
+
+  /**
+   * Build the editor's working list by merging:
+   *   - the saved order (filtered to existing sponsors),
+   *   - any new sponsors not yet present in the order (appended at the end).
+   * This keeps newly added sponsors visible without losing the admin's order.
+   */
+  useEffect(() => {
+    if (sponsors.length === 0) return;
+    const sponsorIds = sponsors.map((s) => Number(s.id));
+    const savedOrder = (savedCarousel.order ?? []).filter((id) => sponsorIds.includes(id));
+    const missing = sponsorIds.filter((id) => !savedOrder.includes(id));
+    setOrderedIds([...savedOrder, ...missing]);
+    setRandomize(Boolean(savedCarousel.randomize));
+    setVisibleCount(savedCarousel.visibleCount ?? DEFAULT_VISIBLE_COUNT);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sponsors, siteConfig?.sponsors_config?.carousel]);
+
+  /** Quick lookup: sponsor by ID */
+  const sponsorById = useMemo(() => {
+    const map = new Map<number, (typeof sponsors)[number]>();
+    sponsors.forEach((s) => map.set(Number(s.id), s));
+    return map;
+  }, [sponsors]);
+
+  /** Total sponsors available for this tournament */
+  const totalSponsors = sponsors.length;
+
+  /** Effective number of logos shown on the public ribbon */
+  const effectiveVisible =
+    visibleCount > 0 ? Math.min(visibleCount, totalSponsors) : totalSponsors;
+
+  /** Detect unsaved changes vs. server-stored config */
+  const hasChanges =
+    JSON.stringify(orderedIds) !== JSON.stringify(savedCarousel.order ?? []) ||
+    Boolean(savedCarousel.randomize) !== randomize ||
+    (savedCarousel.visibleCount ?? DEFAULT_VISIBLE_COUNT) !== visibleCount;
+
+  /** DnD callback — applies the new order returned by react-beautiful-dnd */
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    if (result.destination.index === result.source.index) return;
+    setOrderedIds((prev) => reorder(prev, result.source.index, result.destination!.index));
+  };
+
+  /**
+   * Persist the carousel config to the server, preserving any other sponsors_config
+   * fields (columns, ribbonVisiblePages).
+   */
+  const handleSave = () => {
+    saveSiteConfig.mutate(
+      {
+        password: 'admin2025',
+        sponsors_config: {
+          ...(siteConfig?.sponsors_config ?? { columns: 4 }),
+          carousel: {
+            order: orderedIds,
+            randomize,
+            visibleCount,
+          },
+        },
+      },
+      {
+        onSuccess: () => {
+          toast({
+            title: 'Carrusel guardado',
+            description: randomize
+              ? `Aleatorio activo. Mostrando ${effectiveVisible} de ${totalSponsors} logos.`
+              : `Orden personalizado guardado. Mostrando ${effectiveVisible} de ${totalSponsors} logos.`,
+          });
+        },
+        onError: (err) => {
+          toast({
+            title: 'Error al guardar',
+            description: err.message,
+            variant: 'destructive',
+          });
+        },
+      }
+    );
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -24,20 +165,204 @@ const AdminSponsorsCarousel = () => {
           Carrusel de Patrocinadores
         </CardTitle>
         <CardDescription>
-          Próximamente: configura el carrusel destacado de patrocinadores.
+          Define el orden de los patrocinadores, activa la rotación aleatoria
+          y limita cuántos logos se muestran al mismo tiempo en el ribbon.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <div className="flex flex-col items-center justify-center text-center gap-3 py-10 px-4 rounded-lg border border-dashed border-border bg-muted/30">
-          <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
-            <Wrench className="h-6 w-6 text-primary" />
+      <CardContent className="space-y-6">
+        {isLoadingConfig || isLoadingSponsors ? (
+          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Cargando configuración...
           </div>
-          <p className="text-sm font-medium">Sección en construcción</p>
-          <p className="text-xs text-muted-foreground max-w-md">
-            Aquí podrás configurar el carrusel de patrocinadores: orden, duración por slide,
-            páginas donde se muestra y más. Lo definimos en el siguiente branch.
+        ) : totalSponsors === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-6">
+            No hay patrocinadores registrados para este torneo.
           </p>
-        </div>
+        ) : (
+          <>
+            {/* Header: status + Save button */}
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm text-muted-foreground flex items-center gap-1">
+                <CheckCircle2 className="h-4 w-4 text-primary" />
+                Mostrando{' '}
+                <span className="font-mono font-bold">{effectiveVisible}</span>{' '}
+                de <span className="font-mono font-bold">{totalSponsors}</span>{' '}
+                {randomize ? '(orden aleatorio)' : '(orden personalizado)'}
+              </p>
+              <Button
+                onClick={handleSave}
+                disabled={!hasChanges || saveSiteConfig.isPending}
+                size="sm"
+                className="gap-2"
+              >
+                {saveSiteConfig.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                Guardar cambios
+              </Button>
+            </div>
+
+            {/* Settings: randomize + visible count */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {/* Randomize toggle */}
+              <label
+                htmlFor="carousel-randomize"
+                className={cn(
+                  'flex items-center justify-between gap-3 px-4 py-3 rounded-md border border-border bg-background hover:bg-muted/50 cursor-pointer transition-colors',
+                  randomize && 'border-primary/40 bg-primary/5'
+                )}
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <Shuffle className="h-4 w-4 text-primary shrink-0" />
+                  <div className="flex flex-col min-w-0">
+                    <span className="text-sm font-medium">Orden aleatorio</span>
+                    <span className="text-xs text-muted-foreground">
+                      Cada visita muestra los logos en orden distinto.
+                    </span>
+                  </div>
+                </div>
+                <Switch
+                  id="carousel-randomize"
+                  checked={randomize}
+                  onCheckedChange={setRandomize}
+                />
+              </label>
+
+              {/* Visible count input */}
+              <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-md border border-border bg-background">
+                <div className="flex flex-col min-w-0">
+                  <Label htmlFor="carousel-visible-count" className="text-sm font-medium">
+                    Logos visibles
+                  </Label>
+                  <span className="text-xs text-muted-foreground">
+                    Máximo de logos distintos en el ribbon. 0 = mostrar todos.
+                  </span>
+                </div>
+                <Input
+                  id="carousel-visible-count"
+                  type="number"
+                  min={0}
+                  max={totalSponsors}
+                  value={visibleCount}
+                  onChange={(e) => {
+                    const v = Number(e.target.value);
+                    if (Number.isNaN(v)) return;
+                    setVisibleCount(Math.max(0, Math.min(v, totalSponsors)));
+                  }}
+                  className="w-24 text-right font-mono"
+                />
+              </div>
+            </div>
+
+            {/* Drag-and-drop sponsor list */}
+            <div className="space-y-2">
+              <Label className="text-sm">Orden del carrusel</Label>
+              <p className="text-xs text-muted-foreground">
+                Arrastra para reordenar. Los primeros{' '}
+                <span className="font-mono font-bold">{effectiveVisible}</span>{' '}
+                logos serán los visibles cuando "Logos visibles" sea mayor a 0
+                y el orden aleatorio esté desactivado.
+              </p>
+
+              <DragDropContext onDragEnd={handleDragEnd}>
+                <Droppable droppableId="carousel-list">
+                  {(provided) => (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      className="space-y-1.5"
+                    >
+                      {orderedIds.map((id, index) => {
+                        const sponsor = sponsorById.get(id);
+                        if (!sponsor) return null;
+                        const isWithinVisibleSlice =
+                          visibleCount === 0 || index < effectiveVisible;
+                        return (
+                          <Draggable
+                            key={id}
+                            draggableId={String(id)}
+                            index={index}
+                            isDragDisabled={randomize}
+                          >
+                            {(prov, snapshot) => (
+                              <div
+                                ref={prov.innerRef}
+                                {...prov.draggableProps}
+                                className={cn(
+                                  'flex items-center gap-3 px-3 py-2 rounded-md border border-border bg-background',
+                                  snapshot.isDragging && 'shadow-lg border-primary/40 bg-primary/5',
+                                  randomize && 'opacity-60',
+                                  !isWithinVisibleSlice && !randomize && 'opacity-50'
+                                )}
+                              >
+                                {/* Drag handle */}
+                                <button
+                                  type="button"
+                                  {...prov.dragHandleProps}
+                                  className={cn(
+                                    'shrink-0 p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors',
+                                    randomize && 'cursor-not-allowed opacity-40'
+                                  )}
+                                  aria-label="Arrastrar para reordenar"
+                                  disabled={randomize}
+                                >
+                                  <GripVertical className="h-4 w-4" />
+                                </button>
+
+                                {/* Position number */}
+                                <span className="font-mono text-xs text-muted-foreground w-6 text-right shrink-0">
+                                  {index + 1}
+                                </span>
+
+                                {/* Visibility-within-slice indicator */}
+                                {isWithinVisibleSlice ? (
+                                  <Eye
+                                    className="h-4 w-4 shrink-0 text-primary"
+                                    aria-label="Visible en el ribbon"
+                                  />
+                                ) : (
+                                  <EyeOff
+                                    className="h-4 w-4 shrink-0 text-muted-foreground/60"
+                                    aria-label="Fuera del corte de logos visibles"
+                                  />
+                                )}
+
+                                {/* Logo thumbnail */}
+                                <div className="h-10 w-16 shrink-0 flex items-center justify-center bg-muted/30 border border-border/50 rounded">
+                                  <SponsorLogoImage
+                                    url={sponsor.logoUrl}
+                                    alt={sponsor.name}
+                                    showErrorPlaceholder
+                                    className="max-h-full max-w-full object-contain"
+                                  />
+                                </div>
+
+                                {/* Sponsor name */}
+                                <span
+                                  className={cn(
+                                    'text-sm font-medium truncate flex-1',
+                                    !isWithinVisibleSlice && !randomize && 'text-muted-foreground'
+                                  )}
+                                  title={sponsor.name}
+                                >
+                                  {sponsor.name}
+                                </span>
+                              </div>
+                            )}
+                          </Draggable>
+                        );
+                      })}
+                      {provided.placeholder}
+                    </div>
+                  )}
+                </Droppable>
+              </DragDropContext>
+            </div>
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
+++ b/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
@@ -28,6 +28,8 @@ import {
   Save,
   Shuffle,
   CheckCircle2,
+  ToggleLeft,
+  ToggleRight,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSiteConfig, useSaveSiteConfig } from '@/hooks/useSiteConfig';
@@ -73,8 +75,14 @@ const AdminSponsorsCarousel = () => {
   const [orderedIds, setOrderedIds] = useState<number[]>([]);
   /** Local draft state — randomize on each page load */
   const [randomize, setRandomize] = useState<boolean>(false);
-  /** Local draft state — max distinct logos visible at any time (0 = all) */
+  /** Local draft state — number of logos FULLY visible in the viewport (0 = auto) */
   const [visibleCount, setVisibleCount] = useState<number>(DEFAULT_VISIBLE_COUNT);
+  /**
+   * Local draft state — set of sponsor IDs the admin has enabled for the ribbon.
+   * The ribbon will only display sponsors whose ID is in this set. Null/undefined
+   * server value is treated as "all enabled" on first load.
+   */
+  const [enabledIds, setEnabledIds] = useState<Set<number>>(new Set());
 
   /**
    * Sponsor IDs whose logo image failed to load. These are hidden from the
@@ -118,6 +126,14 @@ const AdminSponsorsCarousel = () => {
     setOrderedIds([...savedOrder, ...missing]);
     setRandomize(Boolean(savedCarousel.randomize));
     setVisibleCount(savedCarousel.visibleCount ?? DEFAULT_VISIBLE_COUNT);
+    // Enabled list: if the server has no whitelist yet, default to ALL sponsors enabled.
+    const savedEnabled = savedCarousel.enabledIds;
+    if (savedEnabled && Array.isArray(savedEnabled)) {
+      // Keep only IDs that still correspond to a renderable sponsor.
+      setEnabledIds(new Set(savedEnabled.filter((id) => sponsorIds.includes(Number(id))).map(Number)));
+    } else {
+      setEnabledIds(new Set(sponsorIds));
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [renderableSponsors, siteConfig?.sponsors_config?.carousel]);
 
@@ -137,9 +153,12 @@ const AdminSponsorsCarousel = () => {
     [sponsors, brokenIds]
   );
 
-  /** How many logos will be visible on screen in the ribbon at any moment. */
+  /** How many logos the admin has actually enabled (= rotate in the ribbon). */
+  const enabledCount = enabledIds.size;
+
+  /** How many logos will be FULLY visible on screen in the ribbon at any moment. */
   const onScreenLogos =
-    visibleCount > 0 ? Math.min(visibleCount, totalSponsors) : totalSponsors;
+    visibleCount > 0 ? Math.min(visibleCount, Math.max(enabledCount, 1)) : Math.max(enabledCount, 1);
 
   /**
    * Human-readable label for the resulting scroll speed (mirrors the logic
@@ -153,10 +172,15 @@ const AdminSponsorsCarousel = () => {
     'estándar';
 
   /** Detect unsaved changes vs. server-stored config */
+  const savedEnabledArray = Array.isArray(savedCarousel.enabledIds)
+    ? [...savedCarousel.enabledIds].map(Number).sort((a, b) => a - b)
+    : null;
+  const draftEnabledArray = [...enabledIds].sort((a, b) => a - b);
   const hasChanges =
     JSON.stringify(orderedIds) !== JSON.stringify(savedCarousel.order ?? []) ||
     Boolean(savedCarousel.randomize) !== randomize ||
-    (savedCarousel.visibleCount ?? DEFAULT_VISIBLE_COUNT) !== visibleCount;
+    (savedCarousel.visibleCount ?? DEFAULT_VISIBLE_COUNT) !== visibleCount ||
+    JSON.stringify(savedEnabledArray) !== JSON.stringify(draftEnabledArray);
 
   /** DnD callback — applies the new order returned by react-beautiful-dnd */
   const handleDragEnd = (result: DropResult) => {
@@ -179,6 +203,7 @@ const AdminSponsorsCarousel = () => {
             order: orderedIds,
             randomize,
             visibleCount,
+            enabledIds: [...enabledIds],
           },
         },
       },

--- a/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
+++ b/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
@@ -187,8 +187,8 @@ const AdminSponsorsCarousel = () => {
           toast({
             title: 'Carrusel guardado',
             description: randomize
-              ? `Aleatorio activo. Mostrando ${effectiveVisible} de ${totalSponsors} logos.`
-              : `Orden personalizado guardado. Mostrando ${effectiveVisible} de ${totalSponsors} logos.`,
+              ? `Aleatorio activo. ${onScreenLogos} logo${onScreenLogos === 1 ? '' : 's'} en pantalla a la vez.`
+              : `Orden personalizado guardado. ${onScreenLogos} logo${onScreenLogos === 1 ? '' : 's'} en pantalla a la vez.`,
           });
         },
         onError: (err) => {

--- a/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
+++ b/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
@@ -6,8 +6,10 @@
  *  - Drag-and-drop ordering of sponsor logos (uses @hello-pangea/dnd).
  *  - Randomize toggle: when on, the ribbon is shuffled on every page load
  *    and the manual order is ignored on the public site (kept here as a fallback).
- *  - Visible count: caps how many distinct sponsor logos appear in the ribbon
- *    at any given time (0 = show all).
+ *  - Visible count: how many sponsor logos fit on screen in the ribbon at any
+ *    given moment. Each slot gets `100% / visibleCount` of the container
+ *    width on the public site. Lower values also speed up the scrolling
+ *    animation slightly so the ribbon doesn't feel sluggish. 0 = auto sizing.
  *
  * Persisted server-side via `sponsors_config.carousel` in the site_config row.
  */
@@ -26,8 +28,6 @@ import {
   Save,
   Shuffle,
   CheckCircle2,
-  Eye,
-  EyeOff,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSiteConfig, useSaveSiteConfig } from '@/hooks/useSiteConfig';
@@ -137,9 +137,20 @@ const AdminSponsorsCarousel = () => {
     [sponsors, brokenIds]
   );
 
-  /** Effective number of logos shown on the public ribbon */
-  const effectiveVisible =
+  /** How many logos will be visible on screen in the ribbon at any moment. */
+  const onScreenLogos =
     visibleCount > 0 ? Math.min(visibleCount, totalSponsors) : totalSponsors;
+
+  /**
+   * Human-readable label for the resulting scroll speed (mirrors the logic
+   * applied in `SponsorRibbon`). Keeps admins informed without exposing
+   * raw seconds.
+   */
+  const speedLabel =
+    visibleCount === 1 ? 'rápida' :
+    visibleCount === 2 ? 'rápida' :
+    visibleCount === 3 ? 'moderada' :
+    'estándar';
 
   /** Detect unsaved changes vs. server-stored config */
   const hasChanges =
@@ -200,7 +211,8 @@ const AdminSponsorsCarousel = () => {
         </CardTitle>
         <CardDescription>
           Define el orden de los patrocinadores, activa la rotación aleatoria
-          y limita cuántos logos se muestran al mismo tiempo en el ribbon.
+          y elige cuántos logos caben en pantalla a la vez en el ribbon.
+          Con menos logos visibles, el ribbon se mueve un poco más rápido.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -234,10 +246,11 @@ const AdminSponsorsCarousel = () => {
             <div className="flex flex-wrap items-center justify-between gap-3">
               <p className="text-sm text-muted-foreground flex items-center gap-1">
                 <CheckCircle2 className="h-4 w-4 text-primary" />
-                Mostrando{' '}
-                <span className="font-mono font-bold">{effectiveVisible}</span>{' '}
-                de <span className="font-mono font-bold">{totalSponsors}</span>{' '}
-                {randomize ? '(orden aleatorio)' : '(orden personalizado)'}
+                <span className="font-mono font-bold">{onScreenLogos}</span> logo
+                {onScreenLogos === 1 ? '' : 's'} en pantalla a la vez · velocidad{' '}
+                <span className="font-bold">{speedLabel}</span>
+                {' · '}
+                {randomize ? 'orden aleatorio' : 'orden personalizado'}
               </p>
               <Button
                 onClick={handleSave}
@@ -294,10 +307,11 @@ const AdminSponsorsCarousel = () => {
               <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-md border border-border bg-background">
                 <div className="flex flex-col min-w-0">
                   <Label htmlFor="carousel-visible-count" className="text-sm font-medium">
-                    Logos visibles
+                    Logos visibles a la vez
                   </Label>
                   <span className="text-xs text-muted-foreground">
-                    Máximo de logos distintos en el ribbon. 0 = mostrar todos.
+                    Cuántos logos caben en pantalla simultáneamente. Con 1–3 el
+                    ribbon se mueve más rápido. 0 = tamaño automático.
                   </span>
                 </div>
                 <Input
@@ -320,10 +334,9 @@ const AdminSponsorsCarousel = () => {
             <div className="space-y-2">
               <Label className="text-sm">Orden del carrusel</Label>
               <p className="text-xs text-muted-foreground">
-                Arrastra para reordenar. Los primeros{' '}
-                <span className="font-mono font-bold">{effectiveVisible}</span>{' '}
-                logos serán los visibles cuando "Logos visibles" sea mayor a 0
-                y el orden aleatorio esté desactivado.
+                Arrastra para reordenar. Todos los logos rotan en el ribbon —
+                el campo "Logos visibles a la vez" solo controla cuántos caben
+                simultáneamente en pantalla.
               </p>
 
               <DragDropContext onDragEnd={handleDragEnd}>
@@ -337,8 +350,6 @@ const AdminSponsorsCarousel = () => {
                       {orderedIds.map((id, index) => {
                         const sponsor = sponsorById.get(id);
                         if (!sponsor) return null;
-                        const isWithinVisibleSlice =
-                          visibleCount === 0 || index < effectiveVisible;
                         return (
                           <Draggable
                             key={id}
@@ -353,8 +364,7 @@ const AdminSponsorsCarousel = () => {
                                 className={cn(
                                   'flex items-center gap-3 px-3 py-2 rounded-md border border-border bg-background',
                                   snapshot.isDragging && 'shadow-lg border-primary/40 bg-primary/5',
-                                  randomize && 'opacity-60',
-                                  !isWithinVisibleSlice && !randomize && 'opacity-50'
+                                  randomize && 'opacity-60'
                                 )}
                               >
                                 {/* Drag handle */}
@@ -376,19 +386,6 @@ const AdminSponsorsCarousel = () => {
                                   {index + 1}
                                 </span>
 
-                                {/* Visibility-within-slice indicator */}
-                                {isWithinVisibleSlice ? (
-                                  <Eye
-                                    className="h-4 w-4 shrink-0 text-primary"
-                                    aria-label="Visible en el ribbon"
-                                  />
-                                ) : (
-                                  <EyeOff
-                                    className="h-4 w-4 shrink-0 text-muted-foreground/60"
-                                    aria-label="Fuera del corte de logos visibles"
-                                  />
-                                )}
-
                                 {/* Logo thumbnail */}
                                 <div className="h-10 w-16 shrink-0 flex items-center justify-center bg-muted/30 border border-border/50 rounded">
                                   <SponsorLogoImage
@@ -401,10 +398,7 @@ const AdminSponsorsCarousel = () => {
 
                                 {/* Sponsor name */}
                                 <span
-                                  className={cn(
-                                    'text-sm font-medium truncate flex-1',
-                                    !isWithinVisibleSlice && !randomize && 'text-muted-foreground'
-                                  )}
+                                  className="text-sm font-medium truncate flex-1"
                                   title={sponsor.name}
                                 >
                                   {sponsor.name}

--- a/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
+++ b/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
@@ -332,23 +332,24 @@ const AdminSponsorsCarousel = () => {
               <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-md border border-border bg-background">
                 <div className="flex flex-col min-w-0">
                   <Label htmlFor="carousel-visible-count" className="text-sm font-medium">
-                    Logos visibles a la vez
+                    Cantidad de logos visibles
                   </Label>
                   <span className="text-xs text-muted-foreground">
-                    Cuántos logos caben en pantalla simultáneamente. Con 1–3 el
-                    ribbon se mueve más rápido. 0 = tamaño automático.
+                    Logos completamente visibles en el ribbon a la vez. Logos
+                    entrando/saliendo cuentan como parciales (ej. 0.5 + 2 + 0.5
+                    = 3 visibles). 0 = tamaño automático.
                   </span>
                 </div>
                 <Input
                   id="carousel-visible-count"
                   type="number"
                   min={0}
-                  max={totalSponsors}
+                  max={Math.max(enabledCount, 1)}
                   value={visibleCount}
                   onChange={(e) => {
                     const v = Number(e.target.value);
                     if (Number.isNaN(v)) return;
-                    setVisibleCount(Math.max(0, Math.min(v, totalSponsors)));
+                    setVisibleCount(Math.max(0, Math.min(v, Math.max(enabledCount, 1))));
                   }}
                   className="w-24 text-right font-mono"
                 />
@@ -357,12 +358,43 @@ const AdminSponsorsCarousel = () => {
 
             {/* Drag-and-drop sponsor list */}
             <div className="space-y-2">
-              <Label className="text-sm">Orden del carrusel</Label>
-              <p className="text-xs text-muted-foreground">
-                Arrastra para reordenar. Todos los logos rotan en el ribbon —
-                el campo "Logos visibles a la vez" solo controla cuántos caben
-                simultáneamente en pantalla.
-              </p>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <Label className="text-sm">Orden y selección de logos</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Arrastra para reordenar. Activa/desactiva el switch para
+                    incluir o excluir cada logo del ribbon. Los logos
+                    desactivados aparecen en gris y no rotan en el ribbon.
+                  </p>
+                </div>
+                {/* Select all / none toggle */}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={() => {
+                    const allIds = renderableSponsors.map((s) => Number(s.id));
+                    if (enabledIds.size === allIds.length) {
+                      setEnabledIds(new Set());
+                    } else {
+                      setEnabledIds(new Set(allIds));
+                    }
+                  }}
+                >
+                  {enabledIds.size === renderableSponsors.length ? (
+                    <>
+                      <ToggleRight className="h-4 w-4" />
+                      Deseleccionar todos
+                    </>
+                  ) : (
+                    <>
+                      <ToggleLeft className="h-4 w-4" />
+                      Seleccionar todos
+                    </>
+                  )}
+                </Button>
+              </div>
 
               <DragDropContext onDragEnd={handleDragEnd}>
                 <Droppable droppableId="carousel-list">
@@ -375,6 +407,7 @@ const AdminSponsorsCarousel = () => {
                       {orderedIds.map((id, index) => {
                         const sponsor = sponsorById.get(id);
                         if (!sponsor) return null;
+                        const isEnabled = enabledIds.has(id);
                         return (
                           <Draggable
                             key={id}
@@ -389,7 +422,8 @@ const AdminSponsorsCarousel = () => {
                                 className={cn(
                                   'flex items-center gap-3 px-3 py-2 rounded-md border border-border bg-background',
                                   snapshot.isDragging && 'shadow-lg border-primary/40 bg-primary/5',
-                                  randomize && 'opacity-60'
+                                  randomize && 'opacity-60',
+                                  !isEnabled && 'opacity-40 grayscale'
                                 )}
                               >
                                 {/* Drag handle */}
@@ -428,6 +462,20 @@ const AdminSponsorsCarousel = () => {
                                 >
                                   {sponsor.name}
                                 </span>
+
+                                {/* Per-sponsor enable toggle */}
+                                <Switch
+                                  checked={isEnabled}
+                                  onCheckedChange={(checked) => {
+                                    setEnabledIds((prev) => {
+                                      const next = new Set(prev);
+                                      if (checked) next.add(id);
+                                      else next.delete(id);
+                                      return next;
+                                    });
+                                  }}
+                                  aria-label={`Mostrar ${sponsor.name} en el ribbon`}
+                                />
                               </div>
                             )}
                           </Draggable>

--- a/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
+++ b/src/components/admin/sponsors/AdminSponsorsCarousel.tsx
@@ -12,7 +12,7 @@
  * Persisted server-side via `sponsors_config.carousel` in the site_config row.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DragDropContext, Droppable, Draggable, type DropResult } from '@hello-pangea/dnd';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -33,7 +33,7 @@ import { cn } from '@/lib/utils';
 import { useSiteConfig, useSaveSiteConfig } from '@/hooks/useSiteConfig';
 import { useToast } from '@/hooks/use-toast';
 import { useSponsors } from '@/hooks/useTournamentData';
-import SponsorLogoImage from '@/components/sponsors/SponsorLogoImage';
+import SponsorLogoImage, { type SponsorLogoStatus } from '@/components/sponsors/SponsorLogoImage';
 
 // ============= Constants =============
 
@@ -77,31 +77,65 @@ const AdminSponsorsCarousel = () => {
   const [visibleCount, setVisibleCount] = useState<number>(DEFAULT_VISIBLE_COUNT);
 
   /**
+   * Sponsor IDs whose logo image failed to load. These are hidden from the
+   * drag-and-drop list to mirror the public Patrocinadores page / ribbon
+   * (sponsors without a working logo are not advertised anywhere).
+   */
+  const [brokenIds, setBrokenIds] = useState<Set<string>>(new Set());
+  const handleStatus = useCallback((id: string, status: SponsorLogoStatus) => {
+    setBrokenIds((prev) => {
+      const isBroken = status === 'error';
+      if (isBroken && prev.has(id)) return prev;
+      if (!isBroken && !prev.has(id)) return prev;
+      const next = new Set(prev);
+      if (isBroken) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+
+  /**
+   * Sponsors that actually have a (working) logo. Sponsors with no `logoUrl`
+   * are excluded immediately; sponsors whose <img> errors are excluded once
+   * the load attempt completes (via `brokenIds`).
+   */
+  const renderableSponsors = useMemo(
+    () => sponsors.filter((s) => Boolean(s.logoUrl) && !brokenIds.has(String(s.id))),
+    [sponsors, brokenIds]
+  );
+
+  /**
    * Build the editor's working list by merging:
    *   - the saved order (filtered to existing sponsors),
    *   - any new sponsors not yet present in the order (appended at the end).
    * This keeps newly added sponsors visible without losing the admin's order.
    */
   useEffect(() => {
-    if (sponsors.length === 0) return;
-    const sponsorIds = sponsors.map((s) => Number(s.id));
+    if (renderableSponsors.length === 0) return;
+    const sponsorIds = renderableSponsors.map((s) => Number(s.id));
     const savedOrder = (savedCarousel.order ?? []).filter((id) => sponsorIds.includes(id));
     const missing = sponsorIds.filter((id) => !savedOrder.includes(id));
     setOrderedIds([...savedOrder, ...missing]);
     setRandomize(Boolean(savedCarousel.randomize));
     setVisibleCount(savedCarousel.visibleCount ?? DEFAULT_VISIBLE_COUNT);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sponsors, siteConfig?.sponsors_config?.carousel]);
+  }, [renderableSponsors, siteConfig?.sponsors_config?.carousel]);
 
   /** Quick lookup: sponsor by ID */
   const sponsorById = useMemo(() => {
     const map = new Map<number, (typeof sponsors)[number]>();
-    sponsors.forEach((s) => map.set(Number(s.id), s));
+    renderableSponsors.forEach((s) => map.set(Number(s.id), s));
     return map;
-  }, [sponsors]);
+  }, [renderableSponsors]);
 
-  /** Total sponsors available for this tournament */
-  const totalSponsors = sponsors.length;
+  /** Total sponsors with a working logo (the only ones we show anywhere) */
+  const totalSponsors = renderableSponsors.length;
+
+  /** Sponsors with no logo at all — surfaced as a hint at the bottom */
+  const missingLogoSponsors = useMemo(
+    () => sponsors.filter((s) => !s.logoUrl || brokenIds.has(String(s.id))),
+    [sponsors, brokenIds]
+  );
 
   /** Effective number of logos shown on the public ribbon */
   const effectiveVisible =
@@ -175,12 +209,27 @@ const AdminSponsorsCarousel = () => {
             <Loader2 className="h-4 w-4 animate-spin" />
             Cargando configuración...
           </div>
-        ) : totalSponsors === 0 ? (
+        ) : sponsors.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-6">
             No hay patrocinadores registrados para este torneo.
           </p>
         ) : (
           <>
+            {/* Hidden probes: trigger image loads for ALL sponsors with a URL
+                so we can detect broken logos and exclude them from the editor. */}
+            <div className="hidden" aria-hidden="true">
+              {sponsors
+                .filter((s) => Boolean(s.logoUrl))
+                .map((s) => (
+                  <SponsorLogoImage
+                    key={`probe-${s.id}`}
+                    url={s.logoUrl}
+                    alt={s.name}
+                    onStatusChange={(status) => handleStatus(String(s.id), status)}
+                  />
+                ))}
+            </div>
+
             {/* Header: status + Save button */}
             <div className="flex flex-wrap items-center justify-between gap-3">
               <p className="text-sm text-muted-foreground flex items-center gap-1">
@@ -204,6 +253,16 @@ const AdminSponsorsCarousel = () => {
                 Guardar cambios
               </Button>
             </div>
+
+            {/* Hint: sponsors excluded because they have no usable logo */}
+            {missingLogoSponsors.length > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {missingLogoSponsors.length} patrocinador
+                {missingLogoSponsors.length === 1 ? '' : 'es'} sin logo válido
+                {missingLogoSponsors.length === 1 ? ' fue ocultado' : ' fueron ocultados'} del
+                carrusel y de la página pública de Patrocinadores.
+              </p>
+            )}
 
             {/* Settings: randomize + visible count */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -100,40 +100,19 @@ const SponsorRibbon = () => {
 
   /**
    * On-screen logo density.
-   *  - >0: each slot is `100% / visibleCount` wide so exactly that many logo
-   *        slots fit in the viewport at once.
-   *  - 0/undefined: legacy auto sizing (logos use their natural width).
+   *  - >0: target number of distinct sponsor logos visible in the viewport
+   *        at any given moment. Slots keep their natural (legacy) width
+   *        — we just repeat the sponsor list enough times to fill the
+   *        viewport with a continuous, interleaved stream of logos.
+   *  - 0/undefined: legacy behavior (single pass of sponsors, repeated 2× for the loop).
    *
-   * To avoid huge empty space when only 1–3 sponsor slots are visible, the
-   * same logo is repeated inside each slot (`logoRepeats`) so the ribbon
-   * stays as visually dense as the legacy 4+ layout. Repeats roughly mirror
-   * how many logos used to fit in that same width:
-   *   1 visible slot → 4 repeats per slot
-   *   2 visible slots → 2 repeats per slot
-   *   3 visible slots → 1.x → use 2 to comfortably fill
-   *   4+              → 1   (no internal repetition)
+   * Repetitions are interleaved (round-robin) so e.g. with sponsors [A, B]
+   * you get [A, B, A, B, A, B, ...] instead of [A, A, A, B, B, B].
    */
   const visibleCount = carousel?.visibleCount ?? 0;
-  const slotStyle: React.CSSProperties | undefined =
-    visibleCount > 0
-      ? { flex: `0 0 ${100 / visibleCount}%`, width: `${100 / visibleCount}%` }
-      : undefined;
-  const slotClass =
-    visibleCount > 0
-      ? 'flex items-center justify-center px-4 opacity-60 hover:opacity-100 transition-opacity duration-300'
-      : 'flex-shrink-0 mx-8 opacity-60 hover:opacity-100 transition-opacity duration-300';
-  /**
-   * How many times each sponsor appears in the rotation. Higher values keep
-   * the ribbon visually dense when only 1–3 slots are visible at a time.
-   * Repetitions are interleaved (round-robin) — NOT grouped — so e.g.
-   * with sponsors [A, B] and 4 repeats you get [A, B, A, B, A, B, A, B]
-   * instead of [A, A, A, A, B, B, B, B].
-   */
-  const sponsorRepeats =
-    visibleCount === 1 ? 4 :
-    visibleCount === 2 ? 2 :
-    visibleCount === 3 ? 2 :
-    1;
+  // Slots always use the legacy fixed-margin layout so logos keep their
+  // natural size — there is no `100%/visibleCount` slot stretching anymore.
+  const slotClass = 'flex-shrink-0 mx-8 opacity-60 hover:opacity-100 transition-opacity duration-300';
 
   /**
    * Animation speed.
@@ -154,23 +133,34 @@ const SponsorRibbon = () => {
   };
 
   /**
-   * Build the visible sequence:
-   *   1) Interleave sponsors `sponsorRepeats` times (round-robin distribution)
-   *      so the same logo never appears back-to-back.
-   *   2) If we still don't have enough slots to cover ≥2× the visible count
-   *      (needed for a seamless infinite loop), repeat the interleaved
-   *      sequence further.
-   *   3) Finally, duplicate once more for the CSS infinite-scroll trick.
+   * Build the visible sequence by repeating the sponsor list enough times
+   * so the ribbon always shows ≥`visibleCount` logos on screen at once,
+   * with the same logo never appearing back-to-back.
+   *
+   * The legacy ribbon comfortably fits ≈4 logos in the viewport. So when
+   * the admin asks for `visibleCount = N`, we need each base "page" of
+   * sponsors repeated enough times to fill ≥N logos per viewport width.
+   * Concretely: `sponsorRepeats = ceil(N / sponsors.length) * baseFactor`
+   * where `baseFactor` lifts low values so 1 sponsor with N=2 → 4 copies
+   * per loop (interleaved becomes A A A A — but with multiple sponsors it
+   * round-robins, e.g. [A,B] × 4 → A,B,A,B,A,B,A,B).
    */
+  // Each sponsor logo (incl. its mx-8 margins) takes ~160 px in the legacy
+  // layout; the container is roughly 1200 px wide on desktop, so ≈7–8 logos
+  // fit in the viewport. We use 8 as the on-screen capacity baseline.
+  const ON_SCREEN_CAPACITY = 8;
+  // How many copies of EACH sponsor we want per viewport pass. With 2
+  // sponsors and visibleCount=2 → ceil(8/2)=4 copies per loop, which
+  // round-robins to [A,B,A,B,A,B,A,B].
+  const copiesPerSponsor =
+    orderedSponsors.length === 0
+      ? 1
+      : Math.max(1, Math.ceil(ON_SCREEN_CAPACITY / orderedSponsors.length));
   const interleaved = orderedSponsors.length === 0
     ? []
-    : Array.from({ length: sponsorRepeats }).flatMap(() => orderedSponsors);
-  const minRepeats =
-    visibleCount > 0 && interleaved.length > 0
-      ? Math.max(2, Math.ceil((visibleCount * 2) / interleaved.length))
-      : 2;
-  const filled = Array.from({ length: minRepeats }).flatMap(() => interleaved);
-  const duplicatedSponsors = [...filled, ...filled];
+    : Array.from({ length: copiesPerSponsor }).flatMap(() => orderedSponsors);
+  // Duplicate once more for the seamless CSS infinite-scroll loop.
+  const duplicatedSponsors = [...interleaved, ...interleaved];
 
   if (orderedSponsors.length === 0 && probeSponsors.length === 0) return null;
 
@@ -183,7 +173,6 @@ const SponsorRibbon = () => {
               <div
                 key={`${sponsor.id}-${index}`}
                 className={slotClass}
-                style={slotStyle}
               >
                 {sponsor.websiteUrl ? (
                   <a

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -18,11 +18,15 @@ import SponsorLogoImage, { type SponsorLogoStatus } from '@/components/sponsors/
  * (managed in /admin → tab Patrocinadores). If no per-page config exists,
  * the ribbon defaults to visible everywhere.
  *
- * Order, randomization and the maximum number of visible logos are admin-controlled
+ * Order, randomization and the on-screen logo count are admin-controlled
  * via `sponsors_config.carousel` (Admin → Patrocinadores → Carrusel):
  *   - carousel.order:        custom display order (array of sponsor IDs)
  *   - carousel.randomize:    shuffle order on every render (overrides custom order)
- *   - carousel.visibleCount: max number of distinct sponsors included in the ribbon
+ *   - carousel.visibleCount: how many logos are visible in the viewport at any
+ *                            given time. Each slot is sized to `100% / visibleCount`
+ *                            of the container width. The full sponsor set still
+ *                            scrolls — this only controls visual density.
+ *                            0 / undefined = legacy auto sizing.
  */
 const SponsorRibbon = () => {
   const { data: sponsors = [] } = useSponsors();
@@ -81,13 +85,8 @@ const SponsorRibbon = () => {
       });
     }
 
-    // Cap the number of distinct logos shown if visibleCount is set (>0)
-    const cap = carousel?.visibleCount ?? 0;
-    if (cap > 0 && list.length > cap) {
-      list = list.slice(0, cap);
-    }
     return list;
-  }, [sponsors, brokenIds, carousel?.randomize, carousel?.order, carousel?.visibleCount]);
+  }, [sponsors, brokenIds, carousel?.randomize, carousel?.order]);
 
   // Per-page visibility map from server config — undefined = legacy default (show everywhere)
   const ribbonVisiblePages = siteConfig?.sponsors_config?.ribbonVisiblePages;
@@ -95,16 +94,52 @@ const SponsorRibbon = () => {
     return null;
   }
 
-  // We still need to mount probes for sponsors not yet evaluated so their
-  // onError callbacks can fire and update `brokenIds`. Build a hidden probe
-  // list of any sponsor that has a URL but isn't in `orderedSponsors` yet.
-  const evaluatedIds = new Set(orderedSponsors.map((s) => String(s.id)));
-  const probeSponsors = sponsors.filter(
-    (s) => Boolean(s.logoUrl) && !evaluatedIds.has(String(s.id)) && !brokenIds.has(String(s.id))
-  );
+  // No need for separate probes anymore: every sponsor with a URL is in
+  // `orderedSponsors` (broken ones drop out once their <img> errors).
+  const probeSponsors: typeof sponsors = [];
 
-  // Duplicate sponsors for infinite scroll effect
-  const duplicatedSponsors = [...orderedSponsors, ...orderedSponsors];
+  /**
+   * On-screen logo density.
+   *  - >0: each slot is `100% / visibleCount` wide so exactly that many logos
+   *        fit in the viewport at once.
+   *  - 0/undefined: legacy auto sizing (logos use their natural width).
+   */
+  const visibleCount = carousel?.visibleCount ?? 0;
+  const slotStyle: React.CSSProperties | undefined =
+    visibleCount > 0
+      ? { flex: `0 0 ${100 / visibleCount}%`, width: `${100 / visibleCount}%` }
+      : undefined;
+  const slotClass =
+    visibleCount > 0
+      ? 'flex items-center justify-center px-4 opacity-60 hover:opacity-100 transition-opacity duration-300'
+      : 'flex-shrink-0 mx-8 opacity-60 hover:opacity-100 transition-opacity duration-300';
+
+  /**
+   * Animation speed.
+   * Base = 30s for 4+ visible logos. With fewer visible logos the loop is
+   * shorter (= faster) so the ribbon doesn't feel sluggish:
+   *   1 visible → ~18s
+   *   2 visible → ~22s
+   *   3 visible → ~26s
+   *   4+ visible → 30s (baseline)
+   */
+  const speedSeconds =
+    visibleCount === 1 ? 18 :
+    visibleCount === 2 ? 22 :
+    visibleCount === 3 ? 26 :
+    30;
+  const animationStyle: React.CSSProperties = {
+    animationDuration: `${speedSeconds}s`,
+  };
+
+  // Duplicate sponsors so the loop wraps seamlessly. If the number of visible
+  // slots is greater than the unique sponsor set, repeat enough times to fill
+  // the viewport AND keep the seamless loop (need ≥2x the visible count).
+  const minRepeats =
+    visibleCount > 0 && orderedSponsors.length > 0
+      ? Math.max(2, Math.ceil((visibleCount * 2) / orderedSponsors.length))
+      : 2;
+  const duplicatedSponsors = Array.from({ length: minRepeats }).flatMap(() => orderedSponsors);
 
   if (orderedSponsors.length === 0 && probeSponsors.length === 0) return null;
 
@@ -112,11 +147,12 @@ const SponsorRibbon = () => {
     <div className="bg-muted/50 border-y border-border py-4 overflow-hidden">
       <div className="container mx-auto">
         <div className="fade-edge-left">
-          <div className="flex items-center sponsor-scroll">
+          <div className="flex items-center sponsor-scroll" style={animationStyle}>
             {duplicatedSponsors.map((sponsor, index) => (
               <div
                 key={`${sponsor.id}-${index}`}
-                className="flex-shrink-0 mx-8 opacity-60 hover:opacity-100 transition-opacity duration-300"
+                className={slotClass}
+                style={slotStyle}
               >
                 {sponsor.websiteUrl ? (
                   <a

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -100,9 +100,18 @@ const SponsorRibbon = () => {
 
   /**
    * On-screen logo density.
-   *  - >0: each slot is `100% / visibleCount` wide so exactly that many logos
-   *        fit in the viewport at once.
+   *  - >0: each slot is `100% / visibleCount` wide so exactly that many logo
+   *        slots fit in the viewport at once.
    *  - 0/undefined: legacy auto sizing (logos use their natural width).
+   *
+   * To avoid huge empty space when only 1–3 sponsor slots are visible, the
+   * same logo is repeated inside each slot (`logoRepeats`) so the ribbon
+   * stays as visually dense as the legacy 4+ layout. Repeats roughly mirror
+   * how many logos used to fit in that same width:
+   *   1 visible slot → 4 repeats per slot
+   *   2 visible slots → 2 repeats per slot
+   *   3 visible slots → 1.x → use 2 to comfortably fill
+   *   4+              → 1   (no internal repetition)
    */
   const visibleCount = carousel?.visibleCount ?? 0;
   const slotStyle: React.CSSProperties | undefined =
@@ -111,8 +120,13 @@ const SponsorRibbon = () => {
       : undefined;
   const slotClass =
     visibleCount > 0
-      ? 'flex items-center justify-center px-4 opacity-60 hover:opacity-100 transition-opacity duration-300'
+      ? 'flex items-center justify-center gap-8 px-4 opacity-60 hover:opacity-100 transition-opacity duration-300'
       : 'flex-shrink-0 mx-8 opacity-60 hover:opacity-100 transition-opacity duration-300';
+  const logoRepeats =
+    visibleCount === 1 ? 4 :
+    visibleCount === 2 ? 2 :
+    visibleCount === 3 ? 2 :
+    1;
 
   /**
    * Animation speed.
@@ -154,28 +168,34 @@ const SponsorRibbon = () => {
                 className={slotClass}
                 style={slotStyle}
               >
-                {sponsor.websiteUrl ? (
-                  <a
-                    href={sponsor.websiteUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block"
-                  >
+                {/* Repeat the same logo inside the slot so wide slots
+                    (low visibleCount) don't show empty space. */}
+                {Array.from({ length: logoRepeats }).map((_, repeatIdx) => {
+                  const onStatus = (s: SponsorLogoStatus) => handleStatus(String(sponsor.id), s);
+                  const logoEl = (
                     <SponsorLogoImage
                       url={sponsor.logoUrl}
                       alt={sponsor.name}
-                      onStatusChange={(s) => handleStatus(String(sponsor.id), s)}
+                      onStatusChange={onStatus}
                       className="h-20 md:h-24 w-auto object-contain grayscale hover:grayscale-0 transition-all duration-300"
                     />
-                  </a>
-                ) : (
-                  <SponsorLogoImage
-                    url={sponsor.logoUrl}
-                    alt={sponsor.name}
-                    onStatusChange={(s) => handleStatus(String(sponsor.id), s)}
-                    className="h-20 md:h-24 w-auto object-contain grayscale hover:grayscale-0 transition-all duration-300"
-                  />
-                )}
+                  );
+                  return sponsor.websiteUrl ? (
+                    <a
+                      key={repeatIdx}
+                      href={sponsor.websiteUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block"
+                    >
+                      {logoEl}
+                    </a>
+                  ) : (
+                    <span key={repeatIdx} className="block">
+                      {logoEl}
+                    </span>
+                  );
+                })}
               </div>
             ))}
             {/* Hidden probes: detect broken logos for sponsors not yet rendered

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -107,19 +107,22 @@ const SponsorRibbon = () => {
 
   /**
    * On-screen logo density.
-   *  - >0: target number of distinct sponsor logos visible in the viewport
-   *        at any given moment. Slots keep their natural (legacy) width
-   *        — we just repeat the sponsor list enough times to fill the
-   *        viewport with a continuous, interleaved stream of logos.
-   *  - 0/undefined: legacy behavior (single pass of sponsors, repeated 2× for the loop).
-   *
-   * Repetitions are interleaved (round-robin) so e.g. with sponsors [A, B]
-   * you get [A, B, A, B, A, B, ...] instead of [A, A, A, B, B, B].
+   *  - >0: number of logos that should be FULLY visible on screen at any
+   *        instant. Each slot occupies `100% / visibleCount` of the container
+   *        width, so logos entering on the right and leaving on the left are
+   *        partial (the spec the admin asked for).
+   *  - 0/undefined: legacy behavior (natural slot width with `mx-8` margins).
    */
   const visibleCount = carousel?.visibleCount ?? 0;
-  // Slots always use the legacy fixed-margin layout so logos keep their
-  // natural size — there is no `100%/visibleCount` slot stretching anymore.
-  const slotClass = 'flex-shrink-0 mx-8 opacity-60 hover:opacity-100 transition-opacity duration-300';
+  // When visibleCount > 0, stretch each slot to `100% / visibleCount` of the
+  // container so exactly N logos fit fully in the viewport at any time.
+  // When 0, fall back to legacy fixed-margin sizing.
+  const slotClass =
+    visibleCount > 0
+      ? 'flex-shrink-0 px-4 flex items-center justify-center opacity-60 hover:opacity-100 transition-opacity duration-300'
+      : 'flex-shrink-0 mx-8 opacity-60 hover:opacity-100 transition-opacity duration-300';
+  const slotStyle: React.CSSProperties =
+    visibleCount > 0 ? { width: `${100 / visibleCount}%` } : {};
 
   /**
    * Animation speed.
@@ -152,17 +155,16 @@ const SponsorRibbon = () => {
    * per loop (interleaved becomes A A A A — but with multiple sponsors it
    * round-robins, e.g. [A,B] × 4 → A,B,A,B,A,B,A,B).
    */
-  // Each sponsor logo (incl. its mx-8 margins) takes ~160 px in the legacy
-  // layout; the container is roughly 1200 px wide on desktop, so ≈7–8 logos
-  // fit in the viewport. We use 8 as the on-screen capacity baseline.
-  const ON_SCREEN_CAPACITY = 8;
-  // How many copies of EACH sponsor we want per viewport pass. With 2
-  // sponsors and visibleCount=2 → ceil(8/2)=4 copies per loop, which
-  // round-robins to [A,B,A,B,A,B,A,B].
+  // Repeat the sponsor list enough times so the ribbon always contains more
+  // logos than fit in a single viewport (otherwise the CSS infinite-scroll
+  // animation would stutter). With slot width = 100%/visibleCount, we need at
+  // least `visibleCount + 1` logos per pass; we use a 2× safety multiplier so
+  // even with 1 sponsor the ribbon stays continuous.
+  const targetPerPass = Math.max(visibleCount > 0 ? visibleCount * 2 : 8, 4);
   const copiesPerSponsor =
     orderedSponsors.length === 0
       ? 1
-      : Math.max(1, Math.ceil(ON_SCREEN_CAPACITY / orderedSponsors.length));
+      : Math.max(1, Math.ceil(targetPerPass / orderedSponsors.length));
   const interleaved = orderedSponsors.length === 0
     ? []
     : Array.from({ length: copiesPerSponsor }).flatMap(() => orderedSponsors);
@@ -180,6 +182,7 @@ const SponsorRibbon = () => {
               <div
                 key={`${sponsor.id}-${index}`}
                 className={slotClass}
+                style={slotStyle}
               >
                 {sponsor.websiteUrl ? (
                   <a

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -4,6 +4,7 @@
  * Data fetched from sponsors.php via useSponsors hook
  */
 
+import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useSponsors } from '@/hooks/useTournamentData';
 import { useSiteConfig } from '@/hooks/useSiteConfig';
@@ -15,6 +16,12 @@ import { useSiteConfig } from '@/hooks/useSiteConfig';
  * Visibility per route is admin-controlled via `sponsors_config.ribbonVisiblePages`
  * (managed in /admin → tab Patrocinadores). If no per-page config exists,
  * the ribbon defaults to visible everywhere.
+ *
+ * Order, randomization and the maximum number of visible logos are admin-controlled
+ * via `sponsors_config.carousel` (Admin → Patrocinadores → Carrusel):
+ *   - carousel.order:        custom display order (array of sponsor IDs)
+ *   - carousel.randomize:    shuffle order on every render (overrides custom order)
+ *   - carousel.visibleCount: max number of distinct sponsors included in the ribbon
  */
 const SponsorRibbon = () => {
   const { data: sponsors = [] } = useSponsors();
@@ -27,10 +34,47 @@ const SponsorRibbon = () => {
     return null;
   }
 
-  if (sponsors.length === 0) return null;
+  /**
+   * Apply admin carousel config (order / randomize / visibleCount) to the
+   * raw sponsor list before duplicating it for the infinite-scroll loop.
+   * Memoized so randomization happens once per mount/data change instead of
+   * on every re-render.
+   */
+  const carousel = siteConfig?.sponsors_config?.carousel;
+  const orderedSponsors = useMemo(() => {
+    if (!sponsors.length) return [];
+    let list = [...sponsors];
+
+    if (carousel?.randomize) {
+      // Fisher–Yates shuffle for an unbiased random order
+      for (let i = list.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [list[i], list[j]] = [list[j], list[i]];
+      }
+    } else if (carousel?.order && carousel.order.length > 0) {
+      // Apply custom order: configured IDs first (in admin order), then any
+      // sponsors not present in the order array (preserves server alphabetical order).
+      const indexById = new Map<number, number>();
+      carousel.order.forEach((id, idx) => indexById.set(id, idx));
+      list.sort((a, b) => {
+        const ai = indexById.has(Number(a.id)) ? (indexById.get(Number(a.id)) as number) : Number.POSITIVE_INFINITY;
+        const bi = indexById.has(Number(b.id)) ? (indexById.get(Number(b.id)) as number) : Number.POSITIVE_INFINITY;
+        return ai - bi;
+      });
+    }
+
+    // Cap the number of distinct logos shown if visibleCount is set (>0)
+    const cap = carousel?.visibleCount ?? 0;
+    if (cap > 0 && list.length > cap) {
+      list = list.slice(0, cap);
+    }
+    return list;
+  }, [sponsors, carousel?.randomize, carousel?.order, carousel?.visibleCount]);
+
+  if (orderedSponsors.length === 0) return null;
 
   // Duplicate sponsors for infinite scroll effect
-  const duplicatedSponsors = [...sponsors, ...sponsors];
+  const duplicatedSponsors = [...orderedSponsors, ...orderedSponsors];
 
   return (
     <div className="bg-muted/50 border-y border-border py-4 overflow-hidden">

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -67,6 +67,13 @@ const SponsorRibbon = () => {
     // additionally filtered via `brokenIds` after render.
     let list = sponsors.filter((s) => Boolean(s.logoUrl) && !brokenIds.has(String(s.id)));
 
+    // Admin whitelist: when `enabledIds` is defined, only render those sponsors.
+    // When undefined (legacy / never configured), show every sponsor with a logo.
+    if (carousel?.enabledIds) {
+      const allow = new Set(carousel.enabledIds.map((n) => Number(n)));
+      list = list.filter((s) => allow.has(Number(s.id)));
+    }
+
     if (carousel?.randomize) {
       // Fisher–Yates shuffle for an unbiased random order
       for (let i = list.length - 1; i > 0; i--) {
@@ -86,7 +93,7 @@ const SponsorRibbon = () => {
     }
 
     return list;
-  }, [sponsors, brokenIds, carousel?.randomize, carousel?.order]);
+  }, [sponsors, brokenIds, carousel?.randomize, carousel?.order, carousel?.enabledIds]);
 
   // Per-page visibility map from server config — undefined = legacy default (show everywhere)
   const ribbonVisiblePages = siteConfig?.sponsors_config?.ribbonVisiblePages;

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -120,9 +120,16 @@ const SponsorRibbon = () => {
       : undefined;
   const slotClass =
     visibleCount > 0
-      ? 'flex items-center justify-center gap-8 px-4 opacity-60 hover:opacity-100 transition-opacity duration-300'
+      ? 'flex items-center justify-center px-4 opacity-60 hover:opacity-100 transition-opacity duration-300'
       : 'flex-shrink-0 mx-8 opacity-60 hover:opacity-100 transition-opacity duration-300';
-  const logoRepeats =
+  /**
+   * How many times each sponsor appears in the rotation. Higher values keep
+   * the ribbon visually dense when only 1–3 slots are visible at a time.
+   * Repetitions are interleaved (round-robin) — NOT grouped — so e.g.
+   * with sponsors [A, B] and 4 repeats you get [A, B, A, B, A, B, A, B]
+   * instead of [A, A, A, A, B, B, B, B].
+   */
+  const sponsorRepeats =
     visibleCount === 1 ? 4 :
     visibleCount === 2 ? 2 :
     visibleCount === 3 ? 2 :
@@ -146,14 +153,24 @@ const SponsorRibbon = () => {
     animationDuration: `${speedSeconds}s`,
   };
 
-  // Duplicate sponsors so the loop wraps seamlessly. If the number of visible
-  // slots is greater than the unique sponsor set, repeat enough times to fill
-  // the viewport AND keep the seamless loop (need ≥2x the visible count).
+  /**
+   * Build the visible sequence:
+   *   1) Interleave sponsors `sponsorRepeats` times (round-robin distribution)
+   *      so the same logo never appears back-to-back.
+   *   2) If we still don't have enough slots to cover ≥2× the visible count
+   *      (needed for a seamless infinite loop), repeat the interleaved
+   *      sequence further.
+   *   3) Finally, duplicate once more for the CSS infinite-scroll trick.
+   */
+  const interleaved = orderedSponsors.length === 0
+    ? []
+    : Array.from({ length: sponsorRepeats }).flatMap(() => orderedSponsors);
   const minRepeats =
-    visibleCount > 0 && orderedSponsors.length > 0
-      ? Math.max(2, Math.ceil((visibleCount * 2) / orderedSponsors.length))
+    visibleCount > 0 && interleaved.length > 0
+      ? Math.max(2, Math.ceil((visibleCount * 2) / interleaved.length))
       : 2;
-  const duplicatedSponsors = Array.from({ length: minRepeats }).flatMap(() => orderedSponsors);
+  const filled = Array.from({ length: minRepeats }).flatMap(() => interleaved);
+  const duplicatedSponsors = [...filled, ...filled];
 
   if (orderedSponsors.length === 0 && probeSponsors.length === 0) return null;
 
@@ -168,34 +185,28 @@ const SponsorRibbon = () => {
                 className={slotClass}
                 style={slotStyle}
               >
-                {/* Repeat the same logo inside the slot so wide slots
-                    (low visibleCount) don't show empty space. */}
-                {Array.from({ length: logoRepeats }).map((_, repeatIdx) => {
-                  const onStatus = (s: SponsorLogoStatus) => handleStatus(String(sponsor.id), s);
-                  const logoEl = (
+                {sponsor.websiteUrl ? (
+                  <a
+                    href={sponsor.websiteUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block"
+                  >
                     <SponsorLogoImage
                       url={sponsor.logoUrl}
                       alt={sponsor.name}
-                      onStatusChange={onStatus}
+                      onStatusChange={(s) => handleStatus(String(sponsor.id), s)}
                       className="h-20 md:h-24 w-auto object-contain grayscale hover:grayscale-0 transition-all duration-300"
                     />
-                  );
-                  return sponsor.websiteUrl ? (
-                    <a
-                      key={repeatIdx}
-                      href={sponsor.websiteUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="block"
-                    >
-                      {logoEl}
-                    </a>
-                  ) : (
-                    <span key={repeatIdx} className="block">
-                      {logoEl}
-                    </span>
-                  );
-                })}
+                  </a>
+                ) : (
+                  <SponsorLogoImage
+                    url={sponsor.logoUrl}
+                    alt={sponsor.name}
+                    onStatusChange={(s) => handleStatus(String(sponsor.id), s)}
+                    className="h-20 md:h-24 w-auto object-contain grayscale hover:grayscale-0 transition-all duration-300"
+                  />
+                )}
               </div>
             ))}
             {/* Hidden probes: detect broken logos for sponsors not yet rendered

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -4,10 +4,11 @@
  * Data fetched from sponsors.php via useSponsors hook
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useSponsors } from '@/hooks/useTournamentData';
 import { useSiteConfig } from '@/hooks/useSiteConfig';
+import SponsorLogoImage, { type SponsorLogoStatus } from '@/components/sponsors/SponsorLogoImage';
 
 /**
  * SponsorRibbon
@@ -35,9 +36,32 @@ const SponsorRibbon = () => {
    * on every re-render.
    */
   const carousel = siteConfig?.sponsors_config?.carousel;
+  /**
+   * Track sponsor IDs whose logo image failed to load. Mirrors the behavior
+   * of the public Patrocinadores page: broken logos are hidden entirely
+   * (no name, no placeholder) so the ribbon never advertises a sponsor we
+   * cannot actually display.
+   */
+  const [brokenIds, setBrokenIds] = useState<Set<string>>(new Set());
+
+  /** Mark/unmark a sponsor as broken based on the image load status. */
+  const handleStatus = useCallback((id: string, status: SponsorLogoStatus) => {
+    setBrokenIds((prev) => {
+      const isBroken = status === 'error';
+      if (isBroken && prev.has(id)) return prev;
+      if (!isBroken && !prev.has(id)) return prev;
+      const next = new Set(prev);
+      if (isBroken) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+
   const orderedSponsors = useMemo(() => {
     if (!sponsors.length) return [];
-    let list = [...sponsors];
+    // Drop sponsors with no logo URL up-front; broken-on-load ones are
+    // additionally filtered via `brokenIds` after render.
+    let list = sponsors.filter((s) => Boolean(s.logoUrl) && !brokenIds.has(String(s.id)));
 
     if (carousel?.randomize) {
       // Fisher–Yates shuffle for an unbiased random order
@@ -63,7 +87,7 @@ const SponsorRibbon = () => {
       list = list.slice(0, cap);
     }
     return list;
-  }, [sponsors, carousel?.randomize, carousel?.order, carousel?.visibleCount]);
+  }, [sponsors, brokenIds, carousel?.randomize, carousel?.order, carousel?.visibleCount]);
 
   // Per-page visibility map from server config — undefined = legacy default (show everywhere)
   const ribbonVisiblePages = siteConfig?.sponsors_config?.ribbonVisiblePages;
@@ -71,10 +95,18 @@ const SponsorRibbon = () => {
     return null;
   }
 
-  if (orderedSponsors.length === 0) return null;
+  // We still need to mount probes for sponsors not yet evaluated so their
+  // onError callbacks can fire and update `brokenIds`. Build a hidden probe
+  // list of any sponsor that has a URL but isn't in `orderedSponsors` yet.
+  const evaluatedIds = new Set(orderedSponsors.map((s) => String(s.id)));
+  const probeSponsors = sponsors.filter(
+    (s) => Boolean(s.logoUrl) && !evaluatedIds.has(String(s.id)) && !brokenIds.has(String(s.id))
+  );
 
   // Duplicate sponsors for infinite scroll effect
   const duplicatedSponsors = [...orderedSponsors, ...orderedSponsors];
+
+  if (orderedSponsors.length === 0 && probeSponsors.length === 0) return null;
 
   return (
     <div className="bg-muted/50 border-y border-border py-4 overflow-hidden">
@@ -93,19 +125,32 @@ const SponsorRibbon = () => {
                     rel="noopener noreferrer"
                     className="block"
                   >
-                    <img
-                      src={sponsor.logoUrl}
+                    <SponsorLogoImage
+                      url={sponsor.logoUrl}
                       alt={sponsor.name}
+                      onStatusChange={(s) => handleStatus(String(sponsor.id), s)}
                       className="h-20 md:h-24 w-auto object-contain grayscale hover:grayscale-0 transition-all duration-300"
                     />
                   </a>
                 ) : (
-                  <img
-                    src={sponsor.logoUrl}
+                  <SponsorLogoImage
+                    url={sponsor.logoUrl}
                     alt={sponsor.name}
+                    onStatusChange={(s) => handleStatus(String(sponsor.id), s)}
                     className="h-20 md:h-24 w-auto object-contain grayscale hover:grayscale-0 transition-all duration-300"
                   />
                 )}
+              </div>
+            ))}
+            {/* Hidden probes: detect broken logos for sponsors not yet rendered
+                so they can be filtered out before showing in the visible slice. */}
+            {probeSponsors.map((sponsor) => (
+              <div key={`probe-${sponsor.id}`} aria-hidden="true" className="hidden">
+                <SponsorLogoImage
+                  url={sponsor.logoUrl}
+                  alt={sponsor.name}
+                  onStatusChange={(s) => handleStatus(String(sponsor.id), s)}
+                />
               </div>
             ))}
           </div>

--- a/src/components/layout/SponsorRibbon.tsx
+++ b/src/components/layout/SponsorRibbon.tsx
@@ -28,12 +28,6 @@ const SponsorRibbon = () => {
   const { data: siteConfig } = useSiteConfig();
   const { pathname } = useLocation();
 
-  // Per-page visibility map from server config — undefined = legacy default (show everywhere)
-  const ribbonVisiblePages = siteConfig?.sponsors_config?.ribbonVisiblePages;
-  if (ribbonVisiblePages && ribbonVisiblePages[pathname] === false) {
-    return null;
-  }
-
   /**
    * Apply admin carousel config (order / randomize / visibleCount) to the
    * raw sponsor list before duplicating it for the infinite-scroll loop.
@@ -70,6 +64,12 @@ const SponsorRibbon = () => {
     }
     return list;
   }, [sponsors, carousel?.randomize, carousel?.order, carousel?.visibleCount]);
+
+  // Per-page visibility map from server config — undefined = legacy default (show everywhere)
+  const ribbonVisiblePages = siteConfig?.sponsors_config?.ribbonVisiblePages;
+  if (ribbonVisiblePages && ribbonVisiblePages[pathname] === false) {
+    return null;
+  }
 
   if (orderedSponsors.length === 0) return null;
 

--- a/src/hooks/useSiteConfig.ts
+++ b/src/hooks/useSiteConfig.ts
@@ -37,13 +37,20 @@ export interface SponsorsConfig {
    *                   (server default) and are appended after the configured ones.
    *  - randomize:     When true, the displayed order is shuffled on every page load.
    *                   The custom `order` is ignored in this case.
-   *  - visibleCount:  Maximum number of distinct sponsor logos to keep "visible"
-   *                   (i.e. included in the ribbon set). 0 / undefined = show all.
+   *  - visibleCount:  Number of logos that should be FULLY visible in the ribbon
+   *                   viewport at any moment. Each slot occupies `100% / visibleCount`
+   *                   of the container width, so logos entering/leaving on the edges
+   *                   are partial (not counted). 0 / undefined = legacy auto sizing.
+   *  - enabledIds:    Whitelist of sponsor IDs allowed to appear in the ribbon.
+   *                   When undefined, all sponsors with a working logo are shown
+   *                   (legacy behavior). When defined (even empty), only the listed
+   *                   IDs are rendered.
    */
   carousel?: {
     order?: number[];
     randomize?: boolean;
     visibleCount?: number;
+    enabledIds?: number[];
   };
 }
 

--- a/src/hooks/useSiteConfig.ts
+++ b/src/hooks/useSiteConfig.ts
@@ -30,6 +30,21 @@ export interface SponsorsConfig {
    * If undefined, the ribbon defaults to visible on every page (legacy behavior).
    */
   ribbonVisiblePages?: Record<string, boolean>;
+  /**
+   * Carousel/ribbon presentation settings.
+   *  - order:         Custom sponsor display order as an array of sponsor IDs (numbers).
+   *                   Sponsors not present in this list fall back to alphabetical order
+   *                   (server default) and are appended after the configured ones.
+   *  - randomize:     When true, the displayed order is shuffled on every page load.
+   *                   The custom `order` is ignored in this case.
+   *  - visibleCount:  Maximum number of distinct sponsor logos to keep "visible"
+   *                   (i.e. included in the ribbon set). 0 / undefined = show all.
+   */
+  carousel?: {
+    order?: number[];
+    randomize?: boolean;
+    visibleCount?: number;
+  };
 }
 
 /** Full server response for site config */


### PR DESCRIPTION
ribbon amount now works as intended
randomizing option for sponsor showcasing enabled
selection of enabled / disabled sponsors enabled
order of sponsors to be shown in ribbon enabled, does not clash with randomizer. if randomizer is enabled, sponsor order is disabled while maintaining sponsor selection logic.


closes #63 